### PR TITLE
Fence terminal issuance, cold-start restoration, cancellation and receipt revocation

### DIFF
--- a/Sources/BigSyncKit/QSSynchronizer/BigSyncBackgroundActor.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/BigSyncBackgroundActor.swift
@@ -447,12 +447,9 @@ public actor BigSyncBackgroundActor {
                 priority: .utility
             ) { @BigSyncBackgroundActor in
                 do {
-                    let evidence = try await synchronizer
-                        .restoredDurablePublicationEvidence()
-#if DEBUG
-                    self.cloudKitE2ELastRestoredPublicationEvidence = evidence
-#endif
-                    try await restorationHandler(evidence)
+                    try await self.restorePublicationEvidence(
+                        from: synchronizer, using: restorationHandler
+                    )
                 } catch {
                     configuration.logger.error(
                         "QSCloudKitSynchronizer >> Could not restore terminal publication evidence: \(error)"
@@ -707,6 +704,27 @@ public actor BigSyncBackgroundActor {
     }
 
     @BigSyncBackgroundActor
+    internal func restorePublicationEvidence(
+        from synchronizer: CloudKitSynchronizer,
+        using handler: BigSyncBackgroundWorkerConfiguration.DurablePublicationEvidenceHandler
+    ) async throws {
+        let attemptID = synchronizer.synchronizationAttemptID
+        try Task.checkCancellation()
+        guard realmSynchronizer === synchronizer else { throw CancellationError() }
+        let evidence = try await synchronizer.restoredDurablePublicationEvidence()
+        try Task.checkCancellation()
+        guard realmSynchronizer === synchronizer,
+              synchronizer.synchronizationAttemptID == attemptID,
+              !synchronizer.accountScopeAuthorityFence.requiresGenerationRotation else { throw CancellationError() }
+#if DEBUG
+        cloudKitE2ELastRestoredPublicationEvidence = evidence
+#endif
+        // The domain callback retains its own final Realm/account admission.
+        // Never deliver old restoration (including nil) to a replacement worker.
+        try await handler(evidence)
+    }
+
+    @BigSyncBackgroundActor
     private func synchronizeCloudKit(
         expectedSynchronizer: CloudKitSynchronizer
     ) async -> CloudKitSynchronizer.SynchronizationResult? {
@@ -714,6 +732,9 @@ public actor BigSyncBackgroundActor {
             return nil
         }
         await publicationRestorationTask?.value
+        // A stale waiter must not clear a successor worker's restoration task
+        // or perform its account preflight after this suspension.
+        guard !Task.isCancelled, realmSynchronizer === expectedSynchronizer else { return nil }
         publicationRestorationTask = nil
         let containerIdentifier = expectedSynchronizer.containerIdentifier
 

--- a/Sources/BigSyncKit/QSSynchronizer/BigSyncBackgroundActor.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/BigSyncBackgroundActor.swift
@@ -638,13 +638,16 @@ public actor BigSyncBackgroundActor {
         using receipt: CloudKitSynchronizer.SynchronizationReceipt,
         authorizedBy authorization: CloudKitSynchronizer.PostBarrierDrainAuthorization
     ) async throws -> CloudKitSynchronizer.CompletedPostBarrierDrain {
-        guard let realmSynchronizer else {
+        guard let synchronizer = realmSynchronizer else {
             throw CancellationError()
         }
-        return try await realmSynchronizer.completedPostBarrierDrain(
+        let completed = try await synchronizer.completedPostBarrierDrain(
             using: receipt,
             authorizedBy: authorization
         )
+        guard realmSynchronizer === synchronizer else { throw CancellationError() }
+        try Task.checkCancellation()
+        return completed
     }
 
     /// Revalidates a completed capability after a domain CloudKit suspension.
@@ -652,12 +655,12 @@ public actor BigSyncBackgroundActor {
     public func revalidateCompletedPostBarrierDrain(
         _ completed: CloudKitSynchronizer.CompletedPostBarrierDrain
     ) async throws {
-        guard let realmSynchronizer else {
+        guard let synchronizer = realmSynchronizer else {
             throw CancellationError()
         }
-        try await realmSynchronizer.revalidateCompletedPostBarrierDrain(
-            completed
-        )
+        try await synchronizer.revalidateCompletedPostBarrierDrain(completed)
+        guard realmSynchronizer === synchronizer else { throw CancellationError() }
+        try Task.checkCancellation()
     }
 
     /// Returns at the deadline even when an underlying CloudKit await does not

--- a/Sources/BigSyncKit/QSSynchronizer/BigSyncDurablePublicationEvidence.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/BigSyncDurablePublicationEvidence.swift
@@ -157,61 +157,79 @@ extension CloudKitSynchronizer {
         )
     }
 
-    /// Restores terminal evidence only when the current CloudKit account,
-    /// replica binding, local cursor, and feed epoch still match it exactly.
+    private struct PublicationRestorationSnapshot {
+        let authority: PublicationRestorationAuthority
+        let evidence: BigSyncDurablePublicationEvidence
+        let adapters: [ObjectIdentifier]
+    }
+
+    private func validatePublicationRestoration(_ snapshot: PublicationRestorationSnapshot) throws {
+        // Includes cancellation, synchronous account-notification poison, the
+        // persisted invalidation generation, full binding/installation and run
+        // ownership. The initial unvalidated fence is not an invalidation event.
+        guard try publicationRestorationAuthority() == snapshot.authority,
+              modelAdapters.map({ ObjectIdentifier($0) }) == snapshot.adapters,
+              try persistedDurablePublicationEvidence() == snapshot.evidence else {
+            throw CancellationError()
+        }
+    }
+
+    private func revalidatePublicationRestoration(_ snapshot: PublicationRestorationSnapshot) async throws -> Bool {
+        try validatePublicationRestoration(snapshot)
+        let account = try await accountIdentifierProvider()
+        try validatePublicationRestoration(snapshot)
+        return Self.accountScopeIdentifier(for: account) == snapshot.evidence.accountScopeIdentifier
+    }
+
+    /// Read-only cold-start inspection, never a newly issued receipt or lease.
+    /// Restored evidence can be handed to the domain only while the same startup
+    /// attempt, saved evidence, account generation and installation still own it.
     func restoredDurablePublicationEvidence() async throws
         -> BigSyncDurablePublicationEvidence? {
+        try Task.checkCancellation()
         guard let evidence = try persistedDurablePublicationEvidence(),
               evidence.zoneOwnerName == recordZoneID.ownerName,
-              evidence.zoneName == recordZoneID.zoneName else {
+              evidence.zoneName == recordZoneID.zoneName else { return nil }
+        let authority = try publicationRestorationAuthority()
+        guard authority.accountState.lease?.accountScopeIdentifier == evidence.accountScopeIdentifier,
+              authority.binding?.activeGenerationIdentifier == evidence.replicaBindingGenerationIdentifier,
+              authority.binding == nil || authority.binding?.activeAccountScopeIdentifier == evidence.accountScopeIdentifier else {
             return nil
         }
-        let accountIdentifier = try await accountIdentifierProvider()
-        let accountScopeIdentifier = Self.accountScopeIdentifier(
-            for: accountIdentifier
+        let snapshot = PublicationRestorationSnapshot(
+            authority: authority, evidence: evidence,
+            adapters: modelAdapters.map { ObjectIdentifier($0) }
         )
-        guard evidence.accountScopeIdentifier == accountScopeIdentifier else {
-            return nil
-        }
-        let replicaBindingGenerationIdentifier = try
-            activeReplicaBindingGenerationIdentifierForRun(
-            accountScopeIdentifier: accountScopeIdentifier
-        )
-        guard evidence.replicaBindingGenerationIdentifier
-                == replicaBindingGenerationIdentifier else {
-            return nil
-        }
+        guard try await revalidatePublicationRestoration(snapshot) else { return nil }
         for adapter in modelAdapters {
             try await adapter.activateTransportNamespace(
-                containerIdentifier: containerIdentifier,
-                databaseScope: database.databaseScope
+                containerIdentifier: containerIdentifier, databaseScope: database.databaseScope
             )
+            guard try await revalidatePublicationRestoration(snapshot) else { return nil }
             try await adapter.activateReplicaBinding(
-                accountScopeIdentifier: accountScopeIdentifier,
-                replicaBindingGenerationIdentifier:
-                    replicaBindingGenerationIdentifier
+                accountScopeIdentifier: evidence.accountScopeIdentifier,
+                replicaBindingGenerationIdentifier: evidence.replicaBindingGenerationIdentifier
             )
+            guard try await revalidatePublicationRestoration(snapshot) else { return nil }
         }
-        // Configuration starts Realm setup asynchronously. Restoration must
-        // join that existing task before inspecting journals and the cursor;
-        // otherwise a cold launch can discard valid evidence as unavailable.
+        // Join the existing Realm setup task, retaining the original startup
+        // ownership across readiness. Do not prepare a new binding or namespace.
         for case let adapter as RealmSwiftAdapter in modelAdapters {
             try await adapter.ensureSetup()
+            try validatePublicationRestoration(snapshot)
         }
-        guard try !adaptersHavePendingChangesAtTerminalBoundary() else {
-            return nil
-        }
-        guard let adapter = modelAdapters.first,
+        // LAST actual-account await. The journal/cursor/feed/evidence checks
+        // below must remain a non-suspending tail, even on a cold launch.
+        guard try await revalidatePublicationRestoration(snapshot) else { return nil }
+        guard try !adaptersHavePendingChangesAtTerminalBoundary(),
+              let adapter = modelAdapters.first,
               try adapter.consumedServerBoundaryIdentifier(
-                accountScopeIdentifier: accountScopeIdentifier,
-                replicaBindingGenerationIdentifier:
-                    replicaBindingGenerationIdentifier,
-                containerIdentifier: containerIdentifier,
-                databaseScope: database.databaseScope
+                accountScopeIdentifier: evidence.accountScopeIdentifier,
+                replicaBindingGenerationIdentifier: evidence.replicaBindingGenerationIdentifier,
+                containerIdentifier: containerIdentifier, databaseScope: database.databaseScope
               ) == evidence.consumedServerBoundaryIdentifier,
-              try adapter.changeFeedEpoch() == evidence.changeFeedEpoch else {
-            return nil
-        }
+              try adapter.changeFeedEpoch() == evidence.changeFeedEpoch else { return nil }
+        try validatePublicationRestoration(snapshot)
         return evidence
     }
 

--- a/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+Sync.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+Sync.swift
@@ -57,10 +57,8 @@ extension CloudKitSynchronizer {
         do {
             reportProgress("terminal-tail-start")
             try await revalidateActiveRunContext(for: attemptID)
-        } catch is CancellationError {
-            return
         } catch {
-            await failSynchronization(error: error)
+            await failTerminalSynchronization(error: error, for: attemptID)
             return
         }
 //        logger.info("QSCloudKitSynchronizer >> Finishing synchronization batch...")
@@ -80,10 +78,8 @@ extension CloudKitSynchronizer {
                 // drain before a terminal receipt is issued.
                 try await adapter.didFinishImport()
                 try await revalidateActiveRunContext(for: attemptID)
-            } catch is CancellationError {
-                return
             } catch {
-                await failSynchronization(error: error)
+                await failTerminalSynchronization(error: error, for: attemptID)
                 return
             }
         }
@@ -96,10 +92,8 @@ extension CloudKitSynchronizer {
             if try adaptersHavePendingChangesAtTerminalBoundary() {
                 synchronizationRequestedWhileRunning = true
             }
-        } catch is CancellationError {
-            return
         } catch {
-            await failSynchronization(error: error)
+            await failTerminalSynchronization(error: error, for: attemptID)
             return
         }
         
@@ -119,10 +113,8 @@ extension CloudKitSynchronizer {
             try await processKillCheckpointHandler?(
                 .localAcknowledgementBeforeTerminalPublication
             )
-        } catch is CancellationError {
-            return
         } catch {
-            await failSynchronization(error: error)
+            await failTerminalSynchronization(error: error, for: attemptID)
             return
         }
 #endif
@@ -133,24 +125,20 @@ extension CloudKitSynchronizer {
                 try await finishChangeFeedMigrationIfNeeded(context: context)
                 try await revalidateRunContext(context)
             }
-        } catch is CancellationError {
-            return
         } catch {
-            await failSynchronization(error: error)
+            await failTerminalSynchronization(error: error, for: attemptID)
             return
         }
         let consumedServerBoundaryIdentifier: String?
         do {
             consumedServerBoundaryIdentifier = try
                 currentConsumedServerBoundaryIdentifier(for: activeRunContext)
-        } catch is CancellationError {
-            return
         } catch {
-            await failSynchronization(error: error)
+            await failTerminalSynchronization(error: error, for: attemptID)
             return
         }
         guard let terminalContext = activeRunContext else {
-            await failSynchronization(error: CancellationError())
+            await failTerminalSynchronization(error: CancellationError(), for: attemptID)
             return
         }
         var publicationBlockers = [DomainBlocker]()
@@ -193,10 +181,8 @@ extension CloudKitSynchronizer {
                         )
                     try await revalidateRunContext(terminalContext)
                 }
-            } catch is CancellationError {
-                return
             } catch {
-                await failSynchronization(error: error)
+                await failTerminalSynchronization(error: error, for: attemptID)
                 return
             }
         }
@@ -232,30 +218,23 @@ extension CloudKitSynchronizer {
                 domainPublicationScopeIdentifier = scope
                 try await revalidateRunContext(terminalContext)
             }
-        } catch is CancellationError {
-            return
         } catch {
-            await failSynchronization(error: error)
+            await failTerminalSynchronization(error: error, for: attemptID)
             return
         }
 
         do {
-            // Application reconciliation is allowed to create upload work.
-            // Repeat the exact terminal journal predicate after it returns;
-            // any new generation is drained before a receipt can exist.
-            if try adaptersHavePendingChangesAtTerminalBoundary() {
-                synchronizationRequestedWhileRunning = true
-            }
+            // Account lookup is the last suspension before the terminal cut.
+            // An ordinary journal writer need not have delivered its debounced
+            // observer yet, so refresh the journal AFTER account lookup too.
             try await revalidateRunContext(terminalContext)
-            if try currentConsumedServerBoundaryIdentifier(
-                for: terminalContext
-            ) != consumedServerBoundaryIdentifier {
+            if try terminalBoundaryNeedsAnotherDrain(
+                context: terminalContext, consumedBoundary: consumedServerBoundaryIdentifier
+            ) {
                 synchronizationRequestedWhileRunning = true
             }
-        } catch is CancellationError {
-            return
         } catch {
-            await failSynchronization(error: error)
+            await failTerminalSynchronization(error: error, for: attemptID)
             return
         }
         if synchronizationRequestedWhileRunning {
@@ -275,16 +254,22 @@ extension CloudKitSynchronizer {
                 // terminal semantic validation reports uncertainty/invalidity.
                 try await beginPublicationConsumptionIfNeeded()
                 try await revalidateRunContext(terminalContext)
+                // The blocked branch has its own awaits. A blocker does not
+                // permit completion at an unconsumed journal/cursor boundary.
+                if try terminalBoundaryNeedsAnotherDrain(
+                    context: terminalContext, consumedBoundary: consumedServerBoundaryIdentifier
+                ) {
+                    restartSynchronizationForTerminalWork()
+                    return
+                }
                 try clearDurablePublicationEvidence()
                 try recordSyncHealth(
                     .semanticBlocked,
                     context: terminalContext
                 )
                 try keyValueStore.bigSyncValidateDurability()
-            } catch is CancellationError {
-                return
             } catch {
-                await failSynchronization(error: error)
+                await failTerminalSynchronization(error: error, for: attemptID)
                 return
             }
             activeReceiptAuthorizationID = nil
@@ -341,20 +326,16 @@ extension CloudKitSynchronizer {
                         consumedServerBoundaryIdentifier,
                     changeFeedEpoch: changeFeedEpoch
                 )
-            } catch is CancellationError {
-                return
             } catch {
-                await failSynchronization(error: error)
+                await failTerminalSynchronization(error: error, for: attemptID)
                 return
             }
         }
         if let context = activeRunContext {
             do {
                 try recordSyncHealth(.succeeded, context: context)
-            } catch is CancellationError {
-                return
             } catch {
-                await failSynchronization(error: error)
+                await failTerminalSynchronization(error: error, for: attemptID)
                 return
             }
         }
@@ -365,7 +346,7 @@ extension CloudKitSynchronizer {
             // local-state commit failed.
             try keyValueStore.bigSyncValidateDurability()
         } catch {
-            await failSynchronization(error: error)
+            await failTerminalSynchronization(error: error, for: attemptID)
             return
         }
 #if DEBUG
@@ -373,10 +354,26 @@ extension CloudKitSynchronizer {
             try await processKillCheckpointHandler?(
                 .terminalEvidenceBeforeCompletionDelivery
             )
-        } catch is CancellationError {
-            return
+            // A diagnostic checkpoint may return, not kill the process. It is
+            // then a real suspension and cannot bypass terminal admission.
+            try await revalidateRunContext(terminalContext)
+            if try terminalBoundaryNeedsAnotherDrain(
+                context: terminalContext, consumedBoundary: consumedServerBoundaryIdentifier
+            ) {
+                try clearDurablePublicationEvidence()
+                restartSynchronizationForTerminalWork()
+                return
+            }
+            if let domainPublicationScopeIdentifier {
+                guard let evidence = try publicationEvidenceForUnconsumedFetch(context: terminalContext),
+                      evidence.runID == terminalContext.runID,
+                      evidence.domainScopeIdentifier == domainPublicationScopeIdentifier else {
+                    throw DurableKeyValueStoreError.mutationNotDurable
+                }
+            }
+            try keyValueStore.bigSyncValidateDurability()
         } catch {
-            await failSynchronization(error: error)
+            await failTerminalSynchronization(error: error, for: attemptID)
             return
         }
 #endif
@@ -414,6 +411,31 @@ extension CloudKitSynchronizer {
         synchronizationTask = nil
         postNotification(.SynchronizerDidSynchronize)
         delegate?.synchronizerDidSync(self)
+    }
+
+    /// Do not await the cancellation barrier from a registered callback: it
+    /// waits for this callback's own defer. A collaborator's CancellationError
+    /// is not proof that another path has already closed our drain.
+    @BigSyncBackgroundActor
+    private func failTerminalSynchronization(error: Error, for attemptID: UUID) async {
+        guard synchronizationAttemptID == attemptID else { return }
+        if error is CancellationError {
+            cancelSynchronization()
+        } else {
+            await failSynchronization(error: error)
+        }
+    }
+
+    /// Point-in-time transport cut. Call only after the last account await;
+    /// any additional await requires another check before terminal delivery.
+    @BigSyncBackgroundActor
+    private func terminalBoundaryNeedsAnotherDrain(
+        context: RunContext, consumedBoundary: String?
+    ) throws -> Bool {
+        try checkRunContext(context)
+        let pending = try adaptersHavePendingChangesAtTerminalBoundary()
+        let currentBoundary = try currentConsumedServerBoundaryIdentifier(for: context)
+        return pending || currentBoundary != consumedBoundary || synchronizationRequestedWhileRunning
     }
 
     @BigSyncBackgroundActor

--- a/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+TerminalReceipt.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+TerminalReceipt.swift
@@ -22,6 +22,18 @@ extension CloudKitSynchronizer {
             throw CancellationError()
         }
         try keyValueStore.bigSyncValidateDurability()
+        if let domainScope = receipt.domainPublicationScopeIdentifier {
+            // A live receipt is not sufficient after its durable publication
+            // evidence has been revoked or the change-feed namespace changed.
+            // Reuse the transport evidence check without restoring readiness,
+            // acknowledging work, or issuing a replacement receipt.
+            guard let context = activeRunContext,
+                  let evidence = try publicationEvidenceForUnconsumedFetch(context: context),
+                  evidence.runID == receipt.runID,
+                  evidence.domainScopeIdentifier == domainScope else {
+                throw CancellationError()
+            }
+        }
         try validateAccountScopeLease(lease)
         try validateTerminalReceiptIdentity(receipt)
     }

--- a/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer.swift
@@ -1913,6 +1913,7 @@ public class CloudKitSynchronizer: NSObject {
             throw CancellationError()
         }
         try checkRunContext(activeRunContext)
+        guard try !adaptersHavePendingChangesAtTerminalBoundary() else { throw CancellationError() }
         try await ensureCurrentAccount(completed.accountIdentifier)
         guard completedPostBarrierDrain == completed,
               activeReceiptAuthorizationID == completed.receiptAuthorizationID,
@@ -1922,7 +1923,8 @@ public class CloudKitSynchronizer: NSObject {
             throw CancellationError()
         }
         try checkRunContext(currentRunContext)
-        guard let adapter = modelAdapters.first,
+        guard try !adaptersHavePendingChangesAtTerminalBoundary(),
+              let adapter = modelAdapters.first,
               try adapter.consumedServerBoundaryIdentifier(
                 accountScopeIdentifier: completed.accountScopeIdentifier,
                 replicaBindingGenerationIdentifier: completed.replicaBindingGenerationIdentifier,

--- a/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer.swift
@@ -1020,6 +1020,10 @@ public class CloudKitSynchronizer: NSObject {
     internal var _testActiveRunCallbackCount: Int {
         activeRunCallbackCount
     }
+
+    internal var _testSynchronizationWaiterCount: Int {
+        synchronizationWaiters.count
+    }
 #endif
     private var runCallbackWaiters = [CheckedContinuation<Void, Never>]()
     private var attemptCallbackContinuations = [
@@ -2811,6 +2815,42 @@ public class CloudKitSynchronizer: NSObject {
                 == expected.invalidationGeneration else {
             throw BigSyncAccountScopeLeaseError.stale
         }
+    }
+
+    /// Read-only startup ownership. This is NOT a live account lease or writer
+    /// permission: a fresh synchronizer deliberately still requires validation.
+    internal struct PublicationRestorationAuthority: Equatable {
+        let attemptID: UUID
+        let installationIdentifier: String
+        let accountState: BigSyncAccountScopeLeaseState
+        let binding: BigSyncReplicaBindingSnapshot?
+    }
+
+    internal func publicationRestorationAuthority() throws -> PublicationRestorationAuthority {
+        try Task.checkCancellation()
+        guard !syncing, !synchronizationDrainIsActive, activeRunContext == nil,
+              !cancelSync, !accountScopeAuthorityFence.requiresGenerationRotation,
+              pendingAccountScopeInvalidation == nil,
+              backupDetectionError == nil, !backupRestoreDetected else {
+            throw CancellationError()
+        }
+        try keyValueStore.bigSyncValidateDurability()
+        guard let installation = BackupDetection.installationIdentifier(
+            namespace: durableStateNamespace, sharedSentinelBaseURL: backupDetectionBaseURL
+        ) else { throw BigSyncReplicaBindingError.corrupt }
+        let binding = accountReplacementPolicy.usesDatasetReplicaBinding
+            ? try BigSyncReplicaBindingStateStore.load(store: keyValueStore, key: replicaBindingStateKey)
+            : nil
+        if accountReplacementPolicy.usesDatasetReplicaBinding {
+            guard let binding, binding.pendingPort == nil,
+                  binding.installationIdentityDigest == BigSyncReplicaBindingStateStore.installationIdentityDigest(for: installation) else {
+                throw CancellationError()
+            }
+        }
+        return PublicationRestorationAuthority(
+            attemptID: synchronizationAttemptID, installationIdentifier: installation,
+            accountState: try readAccountScopeLeaseDurably(), binding: binding
+        )
     }
 
     private func readAccountScopeLeaseDurably() throws

--- a/Tests/BigSyncKitTests/CloudKitTerminalReceiptTests.swift
+++ b/Tests/BigSyncKitTests/CloudKitTerminalReceiptTests.swift
@@ -279,6 +279,248 @@ final class CloudKitTerminalReceiptTests: XCTestCase {
         XCTAssertEqual(fixture.adapter.acknowledgements, 0)
     }
 
+
+    @BigSyncBackgroundActor
+    func testLatePendingEditDuringFinalAccountReadRestartsBeforeReceipt() async throws {
+        let fixture = Fixture(domainScopeIdentifier: "domain-a")
+        fixture.armFinalAccountInjection { fixture.introducePendingEdit() }
+        fixture.adapter.finishImportHook = {
+            if fixture.adapter.hasPendingTerminalChanges {
+                fixture.sawPrematureEvidence = try fixture.synchronizer.cloudKitE2EDurablePublicationEvidence() != nil
+                fixture.forwardedLateWork = true
+                fixture.adapter.hasPendingTerminalChanges = false
+            }
+        }
+        let receipt = try await fixture.drain()
+        XCTAssertTrue(fixture.injected)
+        XCTAssertTrue(fixture.forwardedLateWork)
+        XCTAssertFalse(fixture.sawPrematureEvidence)
+        XCTAssertNotEqual(receipt.runID, fixture.injectedRunID)
+        XCTAssertFalse(fixture.adapter.hasPendingTerminalChanges)
+    }
+
+    @BigSyncBackgroundActor
+    func testChangedCursorDuringFinalAccountReadRestartsBeforeReceipt() async throws {
+        let fixture = Fixture(domainScopeIdentifier: "domain-a")
+        fixture.armFinalAccountInjection { fixture.adapter.boundary = "changed-boundary" }
+        let receipt = try await fixture.drain()
+        XCTAssertTrue(fixture.injected)
+        XCTAssertNotEqual(receipt.runID, fixture.injectedRunID)
+        XCTAssertEqual(receipt.consumedServerBoundaryIdentifier, "changed-boundary")
+    }
+
+    @BigSyncBackgroundActor
+    func testBlockedBranchRechecksLatePendingEditAfterItsOwnAccountAwait() async throws {
+        let fixture = Fixture()
+        fixture.synchronizer.domainPrepublicationHandler = { _ in
+            fixture.synchronizer.publicationConsumptionPending = true
+            return [.init(code: "test-blocker")]
+        }
+        fixture.synchronizer.publicationConsumptionHandler = { _ in
+            guard !fixture.injected else { return }
+            // Consumption itself revalidates once; the blocked branch then
+            // performs the account await whose return must refresh journals.
+            await fixture.account.onNextRead {
+                await fixture.account.onNextRead { await fixture.injectPendingAtCurrentRun() }
+            }
+        }
+        fixture.adapter.finishImportHook = {
+            if fixture.adapter.hasPendingTerminalChanges {
+                fixture.forwardedLateWork = true
+                fixture.adapter.hasPendingTerminalChanges = false
+            }
+        }
+        let result = try await fixture.synchronizer.synchronize()
+        XCTAssertTrue(fixture.injected)
+        XCTAssertTrue(fixture.forwardedLateWork)
+        XCTAssertNil(result.receipt)
+        XCTAssertEqual(result.publicationState, .blocked([.init(code: "test-blocker")]))
+        XCTAssertFalse(fixture.synchronizer.synchronizationDrainIsActive)
+    }
+
+    @BigSyncBackgroundActor
+    func testReturningEvidenceCheckpointRechecksPendingJournalAndRevokesEvidence() async throws {
+        let fixture = Fixture(domainScopeIdentifier: "domain-a")
+        fixture.synchronizer.processKillCheckpointHandler = { point in
+            guard point == .terminalEvidenceBeforeCompletionDelivery, !fixture.injected else { return }
+            XCTAssertNotNil(try fixture.synchronizer.cloudKitE2EDurablePublicationEvidence())
+            fixture.injectPendingAtCurrentRun()
+        }
+        fixture.adapter.finishImportHook = {
+            if fixture.adapter.hasPendingTerminalChanges {
+                fixture.sawPrematureEvidence = try fixture.synchronizer.cloudKitE2EDurablePublicationEvidence() != nil
+                fixture.forwardedLateWork = true
+                fixture.adapter.hasPendingTerminalChanges = false
+            }
+        }
+        let receipt = try await fixture.drain()
+        XCTAssertTrue(fixture.forwardedLateWork)
+        XCTAssertFalse(fixture.sawPrematureEvidence)
+        XCTAssertNotEqual(receipt.runID, fixture.injectedRunID)
+    }
+
+    @BigSyncBackgroundActor
+    func testScopeCollaboratorCancellationClosesOwnedDrainAndAllowsRetry() async throws {
+        let fixture = Fixture()
+        fixture.synchronizer.domainPublicationScopeIdentifierProvider = { throw CancellationError() }
+        await assertCancelled { _ = try await fixture.synchronizer.synchronize() }
+        XCTAssertFalse(fixture.synchronizer.syncing)
+        XCTAssertFalse(fixture.synchronizer.synchronizationDrainIsActive)
+        XCTAssertEqual(fixture.synchronizer._testActiveRunCallbackCount, 0)
+        XCTAssertEqual(fixture.adapter.acknowledgements, 0)
+        fixture.synchronizer.domainPublicationScopeIdentifierProvider = { "recovered-domain" }
+        _ = try await fixture.drain()
+    }
+
+    @BigSyncBackgroundActor
+    func testAdapterCollaboratorCancellationClosesOwnedDrain() async throws {
+        let fixture = Fixture()
+        fixture.adapter.semanticHook = { throw CancellationError() }
+        await assertCancelled { _ = try await fixture.synchronizer.synchronize() }
+        XCTAssertFalse(fixture.synchronizer.syncing)
+        XCTAssertFalse(fixture.synchronizer.synchronizationDrainIsActive)
+        XCTAssertEqual(fixture.synchronizer._testActiveRunCallbackCount, 0)
+    }
+
+    @BigSyncBackgroundActor
+    func testLateAccountCollaboratorCancellationClosesOwnedDrain() async throws {
+        let fixture = Fixture(domainScopeIdentifier: "domain-a")
+        fixture.armFinalAccountInjection { throw CancellationError() }
+        await assertCancelled { _ = try await fixture.synchronizer.synchronize() }
+        XCTAssertTrue(fixture.injected)
+        XCTAssertFalse(fixture.synchronizer.synchronizationDrainIsActive)
+        XCTAssertNil(fixture.synchronizer.activeReceiptAuthorizationID)
+    }
+
+    @BigSyncBackgroundActor
+    func testCancelledCheckpointDoesNotStrandOwnedDrain() async throws {
+        for point in [BigSyncBackgroundWorkerConfiguration.ProcessKillCheckpoint.localAcknowledgementBeforeTerminalPublication,
+                      .terminalEvidenceBeforeCompletionDelivery] {
+            let fixture = Fixture(domainScopeIdentifier: "domain-a")
+            fixture.synchronizer.processKillCheckpointHandler = { checkpoint in
+                if checkpoint == point { throw CancellationError() }
+            }
+            await assertCancelled { _ = try await fixture.synchronizer.synchronize() }
+            XCTAssertFalse(fixture.synchronizer.syncing)
+            XCTAssertFalse(fixture.synchronizer.synchronizationDrainIsActive)
+            XCTAssertNil(fixture.synchronizer.activeReceiptAuthorizationID)
+        }
+    }
+
+    @BigSyncBackgroundActor
+    func testColdStartRestoresWithoutGrantingLiveAccountLease() async throws {
+        let first = Fixture(domainScopeIdentifier: "domain-a", useReplicaBinding: true)
+        let receipt = try await first.drain()
+        let cold = first.reopened()
+        XCTAssertTrue(cold.synchronizer.accountValidationRequired)
+        XCTAssertNil(try cold.synchronizer.accountScopeLease())
+        let writes = cold.store.writes
+        let evidence = try await cold.synchronizer.restoredDurablePublicationEvidence()
+        XCTAssertEqual(evidence?.runID, receipt.runID)
+        XCTAssertEqual(cold.store.writes, writes)
+        XCTAssertTrue(cold.synchronizer.accountValidationRequired)
+        XCTAssertNil(try cold.synchronizer.accountScopeLease())
+        XCTAssertNil(cold.synchronizer.activeRunContext)
+    }
+
+    @BigSyncBackgroundActor
+    func testColdStartAccountSwitchDuringNamespaceActivationRejectsEvidence() async throws {
+        let first = Fixture(domainScopeIdentifier: "domain-a", useReplicaBinding: true)
+        _ = try await first.drain()
+        let cold = first.reopened()
+        cold.adapter.namespaceHook = { await cold.account.replace("account-b") }
+        let evidence = try await cold.synchronizer.restoredDurablePublicationEvidence()
+        XCTAssertNil(evidence)
+        XCTAssertEqual(cold.adapter.bindingActivations, 0)
+    }
+
+    @BigSyncBackgroundActor
+    func testColdStartAccountSwitchDuringBindingActivationRejectsEvidence() async throws {
+        let first = Fixture(domainScopeIdentifier: "domain-a", useReplicaBinding: true)
+        _ = try await first.drain()
+        let cold = first.reopened()
+        cold.adapter.bindingHook = { await cold.account.replace("account-b") }
+        let evidence = try await cold.synchronizer.restoredDurablePublicationEvidence()
+        XCTAssertNil(evidence)
+    }
+
+    @BigSyncBackgroundActor
+    func testColdStartSameAccountBindingReplacementRejectsOriginalEvidence() async throws {
+        let first = Fixture(domainScopeIdentifier: "domain-a", useReplicaBinding: true)
+        _ = try await first.drain()
+        let cold = first.reopened()
+        cold.adapter.namespaceHook = { try cold.replacePersistedBinding() }
+        await assertCancelled { _ = try await cold.synchronizer.restoredDurablePublicationEvidence() }
+        XCTAssertNil(cold.synchronizer.activeReceiptAuthorizationID)
+    }
+
+    @BigSyncBackgroundActor
+    func testColdStartAccountReturnWithNewGenerationRejectsOriginalEvidence() async throws {
+        let first = Fixture(domainScopeIdentifier: "domain-a", useReplicaBinding: true)
+        _ = try await first.drain()
+        let cold = first.reopened()
+        cold.adapter.namespaceHook = {
+            await cold.account.replace("account-b")
+            try cold.advancePersistedLeaseGeneration()
+            await cold.account.replace("original-account")
+        }
+        await assertCancelled { _ = try await cold.synchronizer.restoredDurablePublicationEvidence() }
+    }
+
+    @BigSyncBackgroundActor
+    func testColdStartEvidenceReplacementDuringActivationDoesNotBorrowAdmission() async throws {
+        let first = Fixture(domainScopeIdentifier: "domain-a", useReplicaBinding: true)
+        _ = try await first.drain()
+        let cold = first.reopened()
+        cold.adapter.namespaceHook = { try cold.synchronizer.clearDurablePublicationEvidence() }
+        await assertCancelled { _ = try await cold.synchronizer.restoredDurablePublicationEvidence() }
+    }
+
+    @BigSyncBackgroundActor
+    func testColdStartPoisonBeforeNotificationActorRunsRejectsEvidence() async throws {
+        let first = Fixture(domainScopeIdentifier: "domain-a", useReplicaBinding: true)
+        _ = try await first.drain()
+        let cold = first.reopened()
+        cold.adapter.namespaceHook = { cold.synchronizer.accountScopeAuthorityFence.poison() }
+        await assertCancelled { _ = try await cold.synchronizer.restoredDurablePublicationEvidence() }
+    }
+
+    @BigSyncBackgroundActor
+    func testColdStartSupersededByNewRunCannotReturnOldEvidence() async throws {
+        let first = Fixture(domainScopeIdentifier: "domain-a", useReplicaBinding: true)
+        _ = try await first.drain()
+        let cold = first.reopened()
+        cold.adapter.namespaceHook = { _ = try await cold.drain() }
+        await assertCancelled { _ = try await cold.synchronizer.restoredDurablePublicationEvidence() }
+        XCTAssertNotNil(cold.synchronizer.activeRunContext)
+        XCTAssertFalse(cold.synchronizer.synchronizationDrainIsActive)
+    }
+
+    @BigSyncBackgroundActor
+    func testWorkerReplacementDuringColdStartNeverReceivesOldCallback() async throws {
+        let first = Fixture(domainScopeIdentifier: "domain-a", useReplicaBinding: true)
+        _ = try await first.drain()
+        let cold = first.reopened()
+        let successor = Fixture()
+        let worker = BigSyncBackgroundActor()
+        await worker._test_installSynchronizer(cold.synchronizer)
+        cold.adapter.namespaceHook = { await worker._test_installSynchronizer(successor.synchronizer) }
+        await assertCancelled {
+            try await worker.restorePublicationEvidence(from: cold.synchronizer) { _ in
+                XCTFail("Old restoration must not be handed to replacement worker")
+            }
+        }
+        XCTAssertFalse(successor.synchronizer.cancelSync)
+    }
+
+    @BigSyncBackgroundActor
+    private func assertCancelled(file: StaticString = #filePath, line: UInt = #line,
+                                 _ operation: () async throws -> Void) async {
+        do { try await operation(); XCTFail("Expected cancellation", file: file, line: line) }
+        catch is CancellationError { }
+        catch { XCTFail("Unexpected error: \(error)", file: file, line: line) }
+    }
+
     @BigSyncBackgroundActor
     private func assertRejected(
         file: StaticString = #filePath, line: UInt = #line,
@@ -292,18 +534,28 @@ final class CloudKitTerminalReceiptTests: XCTestCase {
 
     @BigSyncBackgroundActor
     private final class Fixture {
-        let store = ReceiptStore()
+        let store: ReceiptStore
         let transport = ReceiptTransport()
-        let account = ReceiptAccount()
+        let account: ReceiptAccount
+        let identifier: String
+        let useReplicaBinding: Bool
+        let domainScopeIdentifier: String?
+        var injected = false
+        var injectedRunID: UUID?
+        var forwardedLateWork = false
+        var sawPrematureEvidence = false
         let adapter: ReceiptAdapter
         let synchronizer: CloudKitSynchronizer
 
-        init(domainScopeIdentifier: String? = nil, useReplicaBinding: Bool = false) {
-            let zone = CKRecordZone.ID(zoneName: "receipt-fixture-\(UUID().uuidString)",
+        init(domainScopeIdentifier: String? = nil, useReplicaBinding: Bool = false,
+             store: ReceiptStore = ReceiptStore(), account: ReceiptAccount = ReceiptAccount(),
+             identifier: String = UUID().uuidString, zoneID: CKRecordZone.ID? = nil) {
+            self.store = store; self.account = account; self.identifier = identifier
+            self.useReplicaBinding = useReplicaBinding; self.domainScopeIdentifier = domainScopeIdentifier
+            let zone = zoneID ?? CKRecordZone.ID(zoneName: "receipt-fixture-\(UUID().uuidString)",
                 ownerName: CKCurrentUserDefaultName)
             adapter = ReceiptAdapter(zoneID: zone)
-            let account = account
-            synchronizer = CloudKitSynchronizer(identifier: UUID().uuidString,
+            synchronizer = CloudKitSynchronizer(identifier: identifier,
                 containerIdentifier: "iCloud.receipt-fixture", database: transport,
                 recordZoneID: zone, keyValueStore: store,
                 accountIdentifierProvider: { try await account.read() },
@@ -320,6 +572,49 @@ final class CloudKitTerminalReceiptTests: XCTestCase {
         }
 
         func introducePendingEdit() { adapter.hasPendingTerminalChanges = true }
+        func reopened() -> Fixture {
+            Fixture(domainScopeIdentifier: domainScopeIdentifier, useReplicaBinding: useReplicaBinding,
+                    store: store, account: account, identifier: identifier, zoneID: adapter.recordZoneID)
+        }
+
+        func injectPendingAtCurrentRun() {
+            injected = true; injectedRunID = synchronizer.activeRunContext?.runID
+            introducePendingEdit()
+        }
+
+        func armFinalAccountInjection(_ operation: @escaping @BigSyncBackgroundActor @Sendable () throws -> Void) {
+            synchronizer.domainPublicationScopeIdentifierProvider = { [self] in
+                guard !injected else { return domainScopeIdentifier }
+                await account.onNextRead {
+                    await self.account.onNextRead {
+                        try await self.runInjection(operation)
+                    }
+                }
+                return domainScopeIdentifier
+            }
+        }
+
+        func runInjection(_ operation: @BigSyncBackgroundActor @Sendable () throws -> Void) throws {
+            injected = true; injectedRunID = synchronizer.activeRunContext?.runID
+            try operation()
+        }
+
+        func replacePersistedBinding() throws {
+            let key = synchronizer.durableStateKey("ReplicaBinding.v1")
+            var value = try XCTUnwrap(store.object(forKey: key) as? [String: Any])
+            value["activeGenerationIdentifier"] = String(repeating: "e", count: 64)
+            try store.bigSyncSetDurably(value: value, forKey: key)
+        }
+
+        func advancePersistedLeaseGeneration() throws {
+            let key = synchronizer.durableStateKey("AccountScopeLease.v1")
+            let old = try BigSyncAccountScopeLeaseState.load(store: store, key: key)
+            let lease = try XCTUnwrap(old.lease)
+            let next = try BigSyncAccountScopeLeaseState(generation: old.generation + 1,
+                accountScopeIdentifier: lease.accountScopeIdentifier, validatedAt: lease.validatedAt)
+            try next.persist(store: store, key: key)
+        }
+
 
         func postBarrierDrain() async throws -> (
             CloudKitSynchronizer.SynchronizationReceipt,
@@ -444,7 +739,26 @@ private final class ReceiptAdapter: NSObject, ModelAdapter, ChangeFeedResetMigra
         containerIdentifier: String, databaseScope: CKDatabase.Scope) throws -> String? { boundary }
     @BigSyncBackgroundActor
     func changeFeedEpoch() throws -> Int? { epoch }
-    func didFinishImport() async throws { }
+    @BigSyncBackgroundActor var finishImportHook: (@BigSyncBackgroundActor @Sendable () async throws -> Void)?
+    @BigSyncBackgroundActor var namespaceHook: (@BigSyncBackgroundActor @Sendable () async throws -> Void)?
+    @BigSyncBackgroundActor var bindingHook: (@BigSyncBackgroundActor @Sendable () async throws -> Void)?
+    @BigSyncBackgroundActor var semanticHook: (@BigSyncBackgroundActor @Sendable () async throws -> Void)?
+    @BigSyncBackgroundActor var bindingActivations = 0
+    @BigSyncBackgroundActor
+    func didFinishImport() async throws { try await finishImportHook?() }
+    @BigSyncBackgroundActor
+    func activateTransportNamespace(containerIdentifier: String, databaseScope: CKDatabase.Scope) async throws {
+        let hook = namespaceHook; namespaceHook = nil; try await hook?()
+    }
+    @BigSyncBackgroundActor
+    func activateReplicaBinding(accountScopeIdentifier: String, replicaBindingGenerationIdentifier: String?) async throws {
+        bindingActivations += 1
+        let hook = bindingHook; bindingHook = nil; try await hook?()
+    }
+    @BigSyncBackgroundActor
+    func semanticPublicationBlockers() async throws -> [CloudKitSynchronizer.DomainBlocker] {
+        try await semanticHook?(); return []
+    }
     func cancelSynchronization() { }
     func unsetCancellation() async throws { }
     @BigSyncBackgroundActor

--- a/Tests/BigSyncKitTests/CloudKitTerminalReceiptTests.swift
+++ b/Tests/BigSyncKitTests/CloudKitTerminalReceiptTests.swift
@@ -130,6 +130,156 @@ final class CloudKitTerminalReceiptTests: XCTestCase {
     }
 
     @BigSyncBackgroundActor
+    func testDomainReceiptRevalidationIsReadOnlyAtExactDurableBoundary() async throws {
+        let fixture = Fixture(domainScopeIdentifier: "certified-domain")
+        let receipt = try await fixture.drain()
+        XCTAssertEqual(receipt.domainPublicationScopeIdentifier, "certified-domain")
+        let operations = fixture.transport.operations
+        let writes = fixture.store.writes
+        for _ in 0..<3 {
+            try await fixture.synchronizer.revalidateTerminalReceipt(receipt)
+            try fixture.synchronizer.validateTerminalReceipt(receipt)
+        }
+        XCTAssertEqual(fixture.transport.operations, operations)
+        XCTAssertEqual(fixture.store.writes, writes)
+        XCTAssertEqual(fixture.adapter.acknowledgements, 0)
+    }
+
+    @BigSyncBackgroundActor
+    func testClearedDurableEvidenceRevokesDomainReceiptWithoutChangingCursor() async throws {
+        let fixture = Fixture(domainScopeIdentifier: "certified-domain")
+        let receipt = try await fixture.drain()
+        try fixture.synchronizer.clearDurablePublicationEvidence()
+        let writes = fixture.store.writes
+        XCTAssertEqual(fixture.adapter.boundary, receipt.consumedServerBoundaryIdentifier)
+        XCTAssertThrowsError(try fixture.synchronizer.validateTerminalReceipt(receipt))
+        await assertRejected { try await fixture.synchronizer.revalidateTerminalReceipt(receipt) }
+        XCTAssertEqual(fixture.store.writes, writes)
+        XCTAssertEqual(fixture.adapter.acknowledgements, 0)
+    }
+
+    @BigSyncBackgroundActor
+    func testReplacementDomainScopeCannotValidateEarlierReceipt() async throws {
+        let fixture = Fixture(domainScopeIdentifier: "certified-domain")
+        let receipt = try await fixture.drain()
+        let context = try XCTUnwrap(fixture.synchronizer.activeRunContext)
+        try fixture.synchronizer.persistDurablePublicationEvidence(
+            domainScopeIdentifier: "replacement-domain", context: context,
+            consumedServerBoundaryIdentifier: try XCTUnwrap(fixture.adapter.boundary),
+            changeFeedEpoch: try XCTUnwrap(fixture.adapter.epoch))
+        XCTAssertThrowsError(try fixture.synchronizer.validateTerminalReceipt(receipt))
+        await assertRejected { try await fixture.synchronizer.revalidateTerminalReceipt(receipt) }
+        XCTAssertEqual(fixture.adapter.acknowledgements, 0)
+    }
+
+    @BigSyncBackgroundActor
+    func testChangedOrMissingFeedEpochRevokesDomainReceiptAtSameCursor() async throws {
+        let fixture = Fixture(domainScopeIdentifier: "certified-domain")
+        let receipt = try await fixture.drain()
+        for epoch: Int? in [8, nil] {
+            fixture.adapter.epoch = epoch
+            XCTAssertEqual(fixture.adapter.boundary, receipt.consumedServerBoundaryIdentifier)
+            XCTAssertThrowsError(try fixture.synchronizer.validateTerminalReceipt(receipt))
+            await assertRejected { try await fixture.synchronizer.revalidateTerminalReceipt(receipt) }
+        }
+        XCTAssertEqual(fixture.adapter.acknowledgements, 0)
+    }
+
+    @BigSyncBackgroundActor
+    func testEvidenceRevokedDuringAccountAwaitCannotPublishOldReceipt() async throws {
+        let fixture = Fixture(domainScopeIdentifier: "certified-domain")
+        let receipt = try await fixture.drain()
+        await fixture.account.onNextRead {
+            try await fixture.synchronizer.clearDurablePublicationEvidence()
+        }
+        await assertRejected { try await fixture.synchronizer.revalidateTerminalReceipt(receipt) }
+        XCTAssertEqual(fixture.adapter.acknowledgements, 0)
+    }
+
+    @BigSyncBackgroundActor
+    func testNewDrainCanRepublishAfterDurableEvidenceRevocation() async throws {
+        let fixture = Fixture(domainScopeIdentifier: "certified-domain")
+        let first = try await fixture.drain()
+        try fixture.synchronizer.clearDurablePublicationEvidence()
+        await assertRejected { try await fixture.synchronizer.revalidateTerminalReceipt(first) }
+        let replacement = try await fixture.drain()
+        XCTAssertNotEqual(first.runID, replacement.runID)
+        try await fixture.synchronizer.revalidateTerminalReceipt(replacement)
+        await assertRejected { try await fixture.synchronizer.revalidateTerminalReceipt(first) }
+    }
+
+    @BigSyncBackgroundActor
+    func testPostBarrierCapabilityValidatesOnUnchangedWorker() async throws {
+        let fixture = Fixture(useReplicaBinding: true)
+        let worker = BigSyncBackgroundActor()
+        await worker._test_installSynchronizer(fixture.synchronizer)
+        let (receipt, authorization) = try await fixture.postBarrierDrain()
+        let completed = try await worker.completedPostBarrierDrain(using: receipt, authorizedBy: authorization)
+        let operations = fixture.transport.operations
+        let writes = fixture.store.writes
+        try await worker.revalidateCompletedPostBarrierDrain(completed)
+        XCTAssertEqual(fixture.transport.operations, operations)
+        XCTAssertEqual(fixture.store.writes, writes)
+    }
+
+    @BigSyncBackgroundActor
+    func testPostBarrierCompletionRejectsWorkerReplacementDuringAccountRead() async throws {
+        let fixture = Fixture(useReplicaBinding: true)
+        let replacement = Fixture(useReplicaBinding: true)
+        let worker = BigSyncBackgroundActor()
+        await worker._test_installSynchronizer(fixture.synchronizer)
+        let (receipt, authorization) = try await fixture.postBarrierDrain()
+        await fixture.account.onNextRead {
+            await worker._test_installSynchronizer(replacement.synchronizer)
+        }
+        await assertRejected {
+            _ = try await worker.completedPostBarrierDrain(using: receipt, authorizedBy: authorization)
+        }
+        XCTAssertEqual(fixture.adapter.acknowledgements, 0)
+    }
+
+    @BigSyncBackgroundActor
+    func testCompletedPostBarrierRevalidationRejectsWorkerReplacementDuringAccountRead() async throws {
+        let fixture = Fixture(useReplicaBinding: true)
+        let replacement = Fixture(useReplicaBinding: true)
+        let worker = BigSyncBackgroundActor()
+        await worker._test_installSynchronizer(fixture.synchronizer)
+        let (receipt, authorization) = try await fixture.postBarrierDrain()
+        let completed = try await worker.completedPostBarrierDrain(using: receipt, authorizedBy: authorization)
+        await fixture.account.onNextRead {
+            await worker._test_installSynchronizer(replacement.synchronizer)
+        }
+        await assertRejected { try await worker.revalidateCompletedPostBarrierDrain(completed) }
+        XCTAssertEqual(fixture.adapter.acknowledgements, 0)
+    }
+
+    @BigSyncBackgroundActor
+    func testNewPendingEditRejectsCompletedPostBarrierCapability() async throws {
+        let fixture = Fixture(useReplicaBinding: true)
+        let (receipt, authorization) = try await fixture.postBarrierDrain()
+        let completed = try await fixture.synchronizer.completedPostBarrierDrain(
+            using: receipt, authorizedBy: authorization)
+        fixture.adapter.hasPendingTerminalChanges = true
+        await assertRejected { try await fixture.synchronizer.revalidateCompletedPostBarrierDrain(completed) }
+        XCTAssertTrue(fixture.adapter.hasPendingTerminalChanges)
+        XCTAssertEqual(fixture.adapter.acknowledgements, 0)
+    }
+
+    @BigSyncBackgroundActor
+    func testPendingEditDuringAccountAwaitRejectsCompletedPostBarrierCapability() async throws {
+        let fixture = Fixture(useReplicaBinding: true)
+        let (receipt, authorization) = try await fixture.postBarrierDrain()
+        let completed = try await fixture.synchronizer.completedPostBarrierDrain(
+            using: receipt, authorizedBy: authorization)
+        await fixture.account.onNextRead {
+            await fixture.introducePendingEdit()
+        }
+        await assertRejected { try await fixture.synchronizer.revalidateCompletedPostBarrierDrain(completed) }
+        XCTAssertTrue(fixture.adapter.hasPendingTerminalChanges)
+        XCTAssertEqual(fixture.adapter.acknowledgements, 0)
+    }
+
+    @BigSyncBackgroundActor
     private func assertRejected(
         file: StaticString = #filePath, line: UInt = #line,
         _ operation: () async throws -> Void
@@ -148,7 +298,7 @@ final class CloudKitTerminalReceiptTests: XCTestCase {
         let adapter: ReceiptAdapter
         let synchronizer: CloudKitSynchronizer
 
-        init() {
+        init(domainScopeIdentifier: String? = nil, useReplicaBinding: Bool = false) {
             let zone = CKRecordZone.ID(zoneName: "receipt-fixture-\(UUID().uuidString)",
                 ownerName: CKCurrentUserDefaultName)
             adapter = ReceiptAdapter(zoneID: zone)
@@ -159,9 +309,28 @@ final class CloudKitTerminalReceiptTests: XCTestCase {
                 accountIdentifierProvider: { try await account.read() },
                 accountStatusProvider: { .available }, changeFeed: transport,
                 subscriptionStore: transport, zoneStore: transport, recordStore: transport,
+                initialReplicaBindingAdmissionHandler: { _ in },
+                accountReplacementPolicy: useReplicaBinding ? .localDatasetRebootstrap : .serverReconciliation,
                 logger: Logger(label: "TerminalReceiptTests"))
             synchronizer._allowRecordZoneRebindingForTesting()
             synchronizer.addModelAdapter(adapter)
+            if let domainScopeIdentifier {
+                synchronizer.domainPublicationScopeIdentifierProvider = { domainScopeIdentifier }
+            }
+        }
+
+        func introducePendingEdit() { adapter.hasPendingTerminalChanges = true }
+
+        func postBarrierDrain() async throws -> (
+            CloudKitSynchronizer.SynchronizationReceipt,
+            CloudKitSynchronizer.PostBarrierDrainAuthorization
+        ) {
+            // Establish real account/binding state through the normal drain.
+            _ = try await drain()
+            synchronizer.postBarrierSnapshotIdentifierProvider = { "snapshot-scope" }
+            let authorization = try synchronizer.establishPostBarrierDrain(
+                writerBarrierEvidenceID: "test-barrier")
+            return (try await drain(), authorization)
         }
 
         func drain() async throws -> CloudKitSynchronizer.SynchronizationReceipt {
@@ -239,6 +408,7 @@ private final class ReceiptAdapter: NSObject, ModelAdapter, ChangeFeedResetMigra
     var hasChanges: Bool { false }
     var hasPendingTerminalChanges = false
     var boundary: String? = "consumed-boundary"
+    var epoch: Int? = 7
     private var bootstrapActive = false
     private(set) var acknowledgements = 0
     init(zoneID: CKRecordZone.ID) { recordZoneID = zoneID }
@@ -273,7 +443,7 @@ private final class ReceiptAdapter: NSObject, ModelAdapter, ChangeFeedResetMigra
     func consumedServerBoundaryIdentifier(accountScopeIdentifier: String, replicaBindingGenerationIdentifier: String?,
         containerIdentifier: String, databaseScope: CKDatabase.Scope) throws -> String? { boundary }
     @BigSyncBackgroundActor
-    func changeFeedEpoch() throws -> Int? { 7 }
+    func changeFeedEpoch() throws -> Int? { epoch }
     func didFinishImport() async throws { }
     func cancelSynchronization() { }
     func unsetCancellation() async throws { }

--- a/Tests/BigSyncKitTests/CloudKitTerminalReceiptTests.swift
+++ b/Tests/BigSyncKitTests/CloudKitTerminalReceiptTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Logging
 import RealmSwift
 import XCTest
-@testable import BigSyncKit
+@_spi(CloudKitE2E) @testable import BigSyncKit
 
 /// Real synchronizer drains with injected transport/account providers. These
 /// tests do not access a CloudKit account, manufacture journals, or arm a cutoff.


### PR DESCRIPTION
## Current correctness revision

Extends the existing normal-history #5/#6 stack; no imported prerequisite or newer BackupDetection hardening was removed.

Current verified head: `c81161cf92fa73632f90b75c79cf45027986400e`; tree `67f5e8b365a8f1f1591b282f2a587852b7c57a78`. Previous #6 head: `6907a0622671e69b507217420d21f1382bef43e2`.

### Independent review incorporated

- **R1 — issuance:** the final account revalidation precedes the refreshed journal/cursor decision. The blocked-result branch repeats the terminal checks after its own later await. Returning DEBUG completion checkpoints revalidate account, journal/cursor and selected domain evidence before completion. This is point-in-time transport evidence, not a global Realm transaction; consumers must retain receipt revalidation.
- **R2 — cold-start restoration:** read-only ownership captures attempt, installation, persisted binding, persisted account lease/generation, adapter identities and selected saved evidence. Account and ownership are rechecked around asynchronous setup; the final actual-account await is followed by synchronous persisted-state, journal, cursor, epoch and evidence checks. Fresh unvalidated cold starts remain admissible for inspection; no public live-lease prerequisite, authority grant, lease minting, new journal or clearing of `accountValidationRequired` is introduced. The worker fences callback handoff and stale restoration-task cleanup.
- **R3 — cancellation:** terminal failures are tied to their captured attempt. A same-owner collaborator CancellationError uses synchronous `cancelSynchronization()` to complete the drain; obsolete callbacks cannot cancel a successor. The terminal callback never awaits its own callback barrier.

The prior durable-domain receipt revocation and post-barrier worker/pending-work checks remain intact.

### Verification

Seventeen additional native behavioral tests are authored in the existing terminal receipt suite. They cover late pending/cursor changes, blocked/checkpoint paths, collaborator cancellation, legitimate cold start, account/binding/generation/evidence changes and replacement ownership. They have not yet been established as native passes.

Independent Linux probes compile the actual terminal/restoration method bodies and cancellation routine with Foundation-only collaborators. The identical 16-scenario probe reports **4/16 baseline invariants satisfied, 16/16 candidate invariants satisfied**. Baseline exit status is 1, candidate 0. The cold-start and normal-completion controls are included. These probes are not the native package and do not qualify Realm generation acknowledgements, filesystem durability, CloudKit, Objective-C dispatch, real account notification delivery or domain callback transactions.

Swift syntax parsing and `git diff --check` passed. The publication runner checked the exact parent tree, 43,240-byte patch SHA-256 `c7266222fd55fe981c1d3c9bcc236634ba6ba59d7eeaaefef611b3be1e794e39`, and final tree before non-force updating this branch. Staging transport/workflows are not part of this source history.

### Merge boundary

Keep draft pending native qualification of this vendor's receipt, account, cursor, generation and recovery interleavings. In particular, file-backed late-journal admission/acknowledgement, coalesced waiters, ignored cancellation during readiness, and broader cancellation paths still need native coverage and review. A separate Reader-hosted macOS SwiftPM attempt is not a pass unless its exact-head logs establish it.

**Vendor merge readiness and Reader activation are distinct gates.** Full Reader intake/lifecycle/writer-barrier/competing-history implementation is not automatically a prerequisite for merging an independently qualified library increment. Conversely, merging this vendor would not authorize production activation or qualify a Reader release. Reader source activation remains disabled; no release branch, user data or root release gitlink is changed by this PR.