### PR TITLE
Import existing CloudKitE2E SPI in terminal receipt tests

### DIFF
--- a/Tests/BigSyncKitTests/CloudKitTerminalReceiptTests.swift
+++ b/Tests/BigSyncKitTests/CloudKitTerminalReceiptTests.swift
@@ -3,7 +3,7 @@ import Foundation
 import Logging
 import RealmSwift
 import XCTest
-@testable import BigSyncKit
+@_spi(CloudKitE2E) @testable import BigSyncKit
 
 /// Real synchronizer drains with injected transport/account providers. These
 /// tests do not access a CloudKit account, manufacture journals, or arm a cutoff.


### PR DESCRIPTION
## Ready for review — 130 selected native methods passed on the exact committed source

Independent macOS arm64 / Xcode 26.3 / Apple Swift 6.2.4 compilation of #6 c81161cf92fa73632f90b75c79cf45027986400e built production code but failed the terminal test target at five references to existing CloudKitE2E SPI. This one-line fix imports that SPI in CloudKitTerminalReceiptTests.swift, matching the existing import in BigSyncKitTests.swift:

```swift
@_spi(CloudKitE2E) @testable import BigSyncKit
```

No runtime visibility, assertion, test availability, behavior, dependency or package configuration is changed. The fix does not expose test APIs to normal clients or disable any boundary test.

## Exact source

Head **18d1a2c11f267f6d4c25e40c010fbd610c1fc2cf**, tree **f64f42757945c8338d4955418ae4fe539f0a4c8f**, sole parent #6 **c81161cf92fa73632f90b75c79cf45027986400e**. One changed path, one added/one removed line. Corrected test blob **d8ad3cb5731a0492ed3fae2b1501c8937ceead2f**. The original blob **946c98b0947d3bb3c5ef27f4fef1048e60fb0f1d** is recovered exactly by reversing that import replacement.

Publication 34401808800 verifies the exact base, original file blob and reversible replacement before non-force source publication. Audit workflows have no source ancestry in this PR.

## Fresh actual native execution

Read-only run https://github.com/aehlke/manabi-reader/actions/runs/34402028174 completed successfully. It checked out this actual normal vendor commit, with frozen Reader revision 607f1a11's RealmSwiftGaps and SwiftUtilities siblings, then executed the real package. No patch was applied to the candidate before native testing and no substitute mock module was used.

| Debug suite | Passed |
|---|---:|
| CloudKitTerminalReceiptTests | **39** |
| CloudKitSynchronizerAccountFencingTests | **66** |
| AccountAuthorityPersistenceTests | **9** |
| CloudKitCursorPersistenceTests | **8** |
| ChangeFeedRecoveryStateTests | **7** |
| Real Realm pending-mutation terminal-boundary case | **1** |
| Total distinct methods | **130** |

Zero failures, unexpected errors or skips. All 39 terminal methods, including the other worker's 17 newly authored cases, executed successfully. These are existing tests newly qualified here, not 130 newly authored tests. The complete selected method lists were checked for duplicates and overlap.

The downloaded artifact `bigsync-spi-native` **10123991275**, SHA-256 **ba5cc67032d149149c2dcf6613d11cb430706f154ea7f92d67c384c548ece5c5**, retains full compiler/test logs, source/sibling manifests, exact vendor identity, Package.resolved and clean vendor status. Both exit codes are zero. Frozen sibling manifests and all eight resolved dependency revisions match the original failed build exactly.

Original failure remains retained: https://github.com/aehlke/manabi-reader/actions/runs/34400910370 ; artifact 10123609807, SHA-256 c4290c1e76210c9e2ffd5b7b777f6fdd75cf91feeb6fee74f14c5980a473743b. That attempt compiled production but executed no behavior test.

## Concurrent integration and limits

Reader #14 concurrently integrated the underlying c81161c runtime as head 229ed8f, full tree 47c3a4ca7037ff7f287c7f4088b1ace3372c8fbf. The independently published Reader #15 was closed after exact full-tree equality was verified; the other worker's branch remains authoritative. This SPI import is a separate normal vendor child and still needs carrying into the flattened Reader test copy where applicable.

These are native macOS **debug selected-suite** results with injected transport/account collaborators. They are not full BigSync suite, release/ASan, signed CloudKit/disposable-zone, real account switching, physical-device, full Reader or complete file-backed late-journal/acknowledgement qualification. Existing compiler warnings remain. Broader #6 merge gates are not automatically waived by these 130 passes.

No target/release branch, Reader release gitlink, activation setting or user data changed. Library merge readiness and Reader production activation remain distinct decisions.