### PR TITLE
[RA-1 W2] Owned-revision adapter tests; cutover removal dependency gate

### DIFF
--- a/Documentation/ReadingAnalyticsRevisionContract.md
+++ b/Documentation/ReadingAnalyticsRevisionContract.md
@@ -1,0 +1,154 @@
+# RA-1: owned-record revision contract
+
+Worker 2 / BigSyncKit. Source inspected: `2a28f8cfa48fa16c471fa4d54c2689f21567905f`.
+This is the application-model integration contract for W3, not a new transport API.
+Normal Mark/Undo needs no quiescence acquisition, source activation or publication proof.
+
+## Existing APIs W3 should implement
+
+A synchronized owned model implements `ChangeMetadataRecordable`, its normal Realm
+primary key, and the existing semantic validation protocols:
+
+- `BigSyncInboundSemanticRecordValidating`: validate the complete received domain
+  payload and its record type/key/immutable owner. Validate bounds before decoding
+  large assets. An unavailable local resource is not corrupt remote data.
+- `BigSyncInboundSemanticReplacementValidating`: implement both
+  `validateInboundSemanticReplacement(_:existingObject:)` and
+  `inboundSemanticReplacementDisposition(_:existingObject:)`. The latter is the
+  winner decision. Delegate both to one model-owned validation/selection function.
+- Use `BigSyncInboundSemanticTargetValidating` instead only when the decision
+  genuinely requires other state in the target Realm. That hook takes precedence
+  over the replacement hook. Do not introduce a readiness graph for owned analytics.
+- `BigSyncOutboundSemanticObjectValidating`: validate the actual local payload
+  before serialization. Unchanged relay/reseed of a foreign-owned version is
+  replication, not permission to change its owner or increment its revision.
+
+All validators are synchronous and read-only. The adapter calls replacement/target
+selection again inside the actual target write, with the current managed preimage.
+The model must not create journals itself while selecting an inbound winner.
+
+For the same immutable owner and logical record key:
+
+| Received version | Disposition |
+| --- | --- |
+| No existing object | `applyIncomingRecord` after full validation |
+| Higher state revision | `preferIncomingRecord` |
+| Lower state revision | `preferExistingObject` |
+| Equal revision and equal normalized domain value | `preserveExistingObject` (replay) |
+| Equal revision and different domain value, or incompatible immutable identity | Throw a model error using `BigSyncInboundSemanticValidationFailure` diagnostics |
+
+Do not return `applyIncomingRecord` for a higher-version winner: that permits the
+ordinary timestamp/pending-local policy to make the final choice. Do not use
+`preserveExistingObject` for an older server value that needs repair: preservation
+alone does not create upload work when none exists.
+
+A semantic rejection is reported through existing per-record quarantine/disposition
+results. It is not necessarily a thrown failure of the entire `saveChanges` batch.
+Cancellation/resource/admission-unavailable errors retain their operational error
+contract; do not reclassify them as an equal-version conflict.
+
+## What equality means
+
+Compare typed, normalized authored domain values. This includes immutable identity,
+revision, reading memberships/facts/counters/classifications, the domain tombstone,
+and every other authored synchronized field on that same record. On Sessions (or
+owned records containing clocks), duration, clock ownership, end state, metadata and
+pace receipts are part of the versioned payload. Those writes advance record revision
+without necessarily invalidating Undo.
+
+Exclude CloudKit system fields (record change tag, server creation/modification dates,
+encoded system-field archive), synchronizer transport metadata/device UUID, journal
+generation/binding, and deliberately local-only recovery or presentation fields.
+`modifiedAt`/`explicitlyModifiedAt` are conflict/audit metadata, not a fallback winner
+clock after revision selection. Treat `createdAt` according to its actual model
+meaning: exclude a mere audit field, retain it when it represents domain history.
+
+Compare sets/maps by semantic membership and values, not iteration order, JSON bytes,
+CKAsset paths, or checksums of unordered serialization. Preserve order for genuinely
+ordered domain lists. Empty-collection omission must have one explicit decoding rule.
+
+BigSync's existing `BigSyncStringEncodedIntegerModel` and
+`BigSyncStringEncodedIntegerCodec` use canonical decimal **Int64** on the wire.
+Use a nonnegative representable revision and checked advancement, or explicitly agree
+another representation with W3. A conceptual UInt64 is not an implicit promise that
+Realm or this codec accepts values above Int64.max. Never wrap a revision.
+
+## How the real adapter handles the preferences
+
+`RealmSwiftAdapter.saveChanges(in:forceSave:)` evaluates the model decision in its
+final target transaction before ordinary pending-local/timestamp selection:
+
+- A higher incoming winner bypasses ordinary metadata ordering in `applyChanges`.
+  If stale local upload work exists, the selected payload and a **fresh** journal
+  generation replace it together. An old acknowledgement cannot retire that new work.
+- A preferred local winner with a pending journal preserves that journal and payload.
+  With no pending journal, the adapter calls its internal
+  `journalCurrentValuePreservingChangeMetadata(at:)` in the target transaction.
+  This creates ordinary upload work without incrementing the model's revision,
+  changing its owner, or advancing its modification timestamps.
+- The server record's system fields are retained in tracking storage for subsequent
+  conditional retransmission. Target and tracking Realms are not one physical
+  transaction; the existing redelivery/journal mechanisms remain responsible for that
+  boundary. No second outbox is added by RA-1.
+- `forceSave: true` forces import consideration, not unconditional server victory.
+
+The real `CloudKitSynchronizer` upload path receives `serverRecordChanged`, imports
+its server record with `saveChanges(... forceSave: true)`, persists imported changes,
+and uses the ordinary upload loop again. The same preferences therefore govern
+conflict retry, not only ordinary downloads.
+
+An authoritative same-process own echo is validation-only via
+`validateAuthoritativeOwnUploadRecords`. Its returned preference is not applied to
+rewrite the target. A late lower-version own echo must be valid historical input,
+not a semantic conflict merely because the current target is newer. A mutation result
+is acknowledged separately by `didUpload(savedRecords:matchingGenerations:)` using the
+prepared generation, never a newly sampled one. Echo detection is process metadata,
+not a domain installation-ownership check.
+
+## Local authored transaction boundary
+
+Use the existing installation/binding APIs, including `BigSyncClientIdentity` and
+`BigSyncMutationJournalIdentity`. A prepared command retains/rechecks its original
+identity. In the same owning Realm write:
+
+1. Validate the application's owner/lifetime/semantic guard.
+2. Change the domain fields and advance the owned record revision.
+3. Require the throwing journal refresh.
+
+Ordinary writers use `try refreshChangeMetadataRequiringJournal(at:)`. A command
+capturing an identity uses the throwing
+`refreshChangeMetadata(explicitlyModified:at:expectedJournalIdentity:)` overload.
+Let any error escape the enclosing transaction. Do not call the nonthrowing overload
+and assume an outer `try` makes it atomic.
+
+Record revision, local Undo semantic guard, and upload journal generation are three
+different values. A clock-only authored edit advances the first and third, not the
+second. Undo restores reading fields, not clocks, old revisions or old generations.
+
+## Empty state, deletion and restore
+
+A newer empty owned record remains a live version. Do not turn its empty membership
+into a CloudKit hard deletion. A model using `isDeleted` as retained ordered negative
+state must opt into `BigSyncRetainsSyncedTombstone` and validate actual record deletion
+through the existing deletion hook according to its supported domain policy. W3 owns
+that policy; ordinary generic deletion is not indefinite negative-state retention.
+
+Restore/reseed preserves original owner/revision/domain values. A new journal
+installation/binding may transport those unchanged values; it must not turn copied
+bytes into a newly authored version or silently admit stale history as current truth.
+W8 supplies the explicit baseline/restore admission decisions. No live restore,
+baseline choice, state clearing or migration is authorized by this note.
+
+## Qualification and removal boundary
+
+The source above already provides the required preference APIs. No production change
+is justified solely by the need for decreasing owned values. The targeted RA-1 suite
+uses a real Realm model, real target/tracking Realms and the actual adapter; remote IO
+may be scripted. Native tests must run on the W1-approved runner. Syntax checks or a
+portable comparator do not qualify the adapter or the actual Common models.
+
+W6/W8 must confirm removal of accepted-head/final-drain/seal/source-publication callers
+before W2 deletes their exported APIs. Ordinary upload currently uses outbound admission
+and submitted-operation uncertainty bookkeeping; those are not an Undo dependency and
+must not be removed by filename. Existing persisted physical uncertainty is never
+silently cleared or interpreted as settled.

--- a/Documentation/ReadingAnalyticsWorker2.md
+++ b/Documentation/ReadingAnalyticsWorker2.md
@@ -1,0 +1,122 @@
+# RA-1 Worker 2 — published tests and remaining collapse boundary
+
+## Status
+
+First deliverable is published; native qualification and cutover removal are NOT
+complete. No production source has been changed merely to add a new revision API.
+The existing adapter preferences already express the required decision; the new
+native suite must qualify their execution before this is called proven.
+
+- Preserved input/base: `2a28f8cfa48fa16c471fa4d54c2689f21567905f`.
+- Work branch: `codex/reading-analytics-w2-sync-20260911`.
+- Target: `codex/reading-analytics-integration-20260911`.
+- Draft PR: https://github.com/lake-of-fire/BigSyncKit/pull/10 .
+- Coordinator: https://github.com/aehlke/manabi-reader/issues/21 .
+- Actual API note: `99c404cf07a19caf76b6b66fd916c40f1e08e674`,
+  [ReadingAnalyticsRevisionContract.md](ReadingAnalyticsRevisionContract.md).
+- Native test source: `eefb5d24edc719b9ed009de49b801f44be721064`,
+  `Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift`.
+- Verified test blob: `453bfbde493f34d01de977fab97b6c464c6de241`.
+- Test SHA-256: `0b4e588d76e5eefd21bc15e5f77dd6e773561bba8e36ce3e590677884c3aec57`.
+
+## Implemented test surface
+
+The fixture is an actual Realm Object using the existing integer codec and model
+validation/preference protocols. Target and tracking Realms, mutation registration,
+throwing journal generation, import, serialization, own-echo validation and
+acknowledgement are real BigSync code. The two conflict-loop methods call the real
+`CloudKitSynchronizer.synchronizeAdapter`, including outbound admission and normal
+`serverRecordChanged -> forceSave import -> reprepare -> acknowledge` handling.
+Only remote IO is scripted; unexpected remote operations throw. The direct-upload
+run uses the same real account-validation/test-run setup as existing native tests,
+not a replacement admission coordinator or fabricated terminal receipt.
+
+This model is not the Common model. W3 owns real application conformance and W1
+owns qualification of the composed tuple. The clock test proves no Common inverse:
+it checks transport of an explicitly supplied complete higher-version payload.
+Reseed uses isolated in-memory data and a controlled empty destination; it does not
+select a real user's baseline or qualify stale-copy admission.
+
+W1 must register the new file in its explicit Tuist native test membership. SwiftPM
+already discovers files in the existing BigSyncKitTests directory. Exact class and
+method identifiers (12 methods, with bounded forceSave/tombstone variants):
+
+```text
+OwnedRecordRevisionTests/testLatePopulatedDownloadRequeuesNewerEmptyValueWithoutReauthoring
+OwnedRecordRevisionTests/testHigherIncomingRevisionReplacesPendingValueAndMintsNewGeneration
+OwnedRecordRevisionTests/testOlderOwnEchoAndG1AcknowledgementCannotRetireG2
+OwnedRecordRevisionTests/testClockRevisionThenUndoTransportsNewestCompletePayload
+OwnedRecordRevisionTests/testEqualRevisionReplayNormalizesSetsAndIgnoresAuditMetadata
+OwnedRecordRevisionTests/testEqualRevisionDivergenceIsQuarantinedWithoutLosingPendingWork
+OwnedRecordRevisionTests/testOmittedEmptyMembershipIsTheSameDomainReplay
+OwnedRecordRevisionTests/testChangedOwnerCannotAddressExistingRecordEvenWithHigherRevision
+OwnedRecordRevisionTests/testRequiredJournalIdentityFailureRollsBackDomainAndRevision
+OwnedRecordRevisionTests/testReseedKeepsOriginalOwnerAndRevisionUnderNewJournalIdentity
+OwnedRecordRevisionTests/testRealUploadLoopRetriesLowerServerConflictWithNewerLocalEmptyState
+OwnedRecordRevisionTests/testRealUploadLoopReplacesStalePendingMarkWithNewerServerEmptyState
+```
+
+Executed: Swift frontend syntax parse with DEBUG defined, local file hashing and
+GitHub blob readback. NOT executed: Apple typecheck, native Realm tests, composed
+Reader tests, actual CloudKit requests or signed multidevice scenarios. No green
+historical suite is relabeled as evidence for this test commit.
+
+## Removal inventory and exact dependency boundary
+
+W6 Core PR #7 currently describes old orchestration as not yet removed. W8 Core
+PR #6 retains its real backup/restore handoff while implementing explicit import.
+Neither has supplied the required dependency-closed exported-API removal SHA.
+W2 has requested that confirmation in the umbrella issue. Do not delete exported
+APIs before their callers disappear, and do not leave successful no-op aliases.
+
+| Current BigSync surface | Disposition for the collapse batch |
+| --- | --- |
+| `CloudKitSynchronizer+AcceptedHeadQuiescence.swift` (120 lines) | Entire extension is accepted-head host orchestration; candidate for deletion with W6 accepted-head callers and exclusively matching tests/probes. |
+| `CloudKitSynchronizer+PausedOutboundRecovery.swift` (115 lines) | Sealed-domain reservation ownership handoff; candidate with W6/W8 paused-adoption callers. Not the ordinary replay implementation. |
+| `CloudKitSynchronizer+OutboundCompletion.swift` | Source-publication completion/token wrappers are candidates. Distinguish the generic external-owner recovery overload before deleting a whole file. |
+| `CloudKitSynchronizer+OutboundQuiescence.swift` | Mixed. Remove final-drain/reservation/source-publication entry points only with their clients. Retain ordinary principal, admission, submitted-request identity and local-settlement handling. |
+| `CloudKitSynchronizer.swift`, `CloudKitSynchronizer+Sync.swift`, `BigSyncBackgroundActor.swift` | Remove cutover configuration/tokens/run branches and forwarding methods as one closed batch. Preserve ordinary run/account/cancellation checks and independently used terminal/change-feed contracts. |
+| `BigSyncOutboundQuiescence.swift` | Mixed persistent format, physical admission, submission markers and old barrier operations. Never delete or reinterpret existing barrier/submission state as settled. Preserve diagnostic decoding and ordinary submission safety while removing domain-only operations. |
+| `CloudKitSynchronizer+OutboundReplayRecovery.swift` | Retain actual operation-identity validation, callback replay, generation-matched handling and unknown-result preservation. A failed operation lookup does not prove mutation rejection. |
+| `CloudKitRecordStore.swift`, `CloudKitSynchronizer+RecordMutations.swift` | Retain once-only callback collector, partial-result preservation, response identity checks and normal retry/acknowledgement flow. |
+| `SyncedEntityProtocol.swift`, `BigSyncPendingMutation.swift`, semantic hooks, identity/binding/restore files | Retain strict journals, generation safety, model winner semantics and owner/binding boundaries. No Reader Undo protocol belongs here. |
+
+This is a dependency checklist, not a new lifecycle design. It does not authorize
+clearing a physical checkpoint, starting source mode, or silently reopening an old
+paused installation. A real-data decision about an existing barrier remains a
+named W1/W8 release boundary; isolated code/tests do not need that permission.
+
+## Runtime reachability retained at this commit
+
+Ordinary upload/delete still invokes `admitOutboundBatch`, then
+`modifyRecordsHoldingOutboundLease`. The latter persists original record IDs,
+prepared generations and optional long-lived operation identity before submission.
+A known server result is not enough: marker retirement follows generation-matched
+local handling. Missing results, lost proxies, cancellation and account replacement
+must not be turned into successful settlement during collapse.
+
+The 982-line low-level outbound file, 633-line synchronizer quiescence extension,
+439-line replay extension and host-only extensions are still present, not counted
+as removed. Ordinary work reaches portions of the first three; the host-only paths
+remain callable by existing Core. RA-1 itself acquires no new barrier or publication
+proof. Removing a feature consumer is not proof that all this general code is dead.
+
+## Accounting and next gates
+
+At test commit `eefb5d24`: 562 test lines, 154 API-document lines, 0 new/reimplemented
+production lines, 0 production deletions, 0 identical moves. This status note is
+additional documentation only. No unrelated production tests, workflows, manifests,
+identity formats or callback behavior were altered.
+
+1. W1-approved native runner executes the 12 methods and retained account,
+   cancellation, partial-result, callback lifetime and generation suites. Fix any
+   demonstrated adapter gap, not the public API simply because a new model exists.
+2. W6/W8 publish removal SHAs for accepted-head, final aggregate drain/seal, paused
+   reservation/source publication and completion clients. W2 performs the closed
+   removal batch, preserving ordinary physical uncertainty. This gate is currently
+   outstanding; the assignment must not be labeled fully collapsed.
+3. W1 composes the actual Common conformance and owning Mark/Undo transactions with
+   this transport, registers tests and records native/signed qualification separately.
+
+No release/default merge, force push, live migration, account/zone deletion, journal
+clearing, source activation or Mac worktree change was performed.

--- a/Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift
+++ b/Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift
@@ -1,0 +1,562 @@
+import CloudKit
+import Foundation
+import Logging
+import RealmSwift
+import RealmSwiftGaps
+import XCTest
+@_spi(CloudKitE2E) @testable import BigSyncKit
+
+#if DEBUG
+// A real Realm model exercising BigSync's existing hooks, not the Common model.
+// Every test below uses the actual target/tracking Realms, journal and adapter.
+private enum RA1RevisionError: Error, BigSyncInboundSemanticValidationFailure {
+    case invalidPayload, changedIdentity, divergentEqualRevision, unexpectedIO
+    var bigSyncValidationCode: String { "ra1-test-\(self)" }
+}
+
+private struct RA1DomainValue: Equatable, Sendable {
+    var owner = "owner-a"
+    var key = "article-a:page-0"
+    var revision: Int64
+    var segments: Set<String>
+    var characters: Int64
+    var activeMicroseconds: Int64 = 100
+    var title = "Article"
+    var deleted = false
+    var id: String { owner + "|" + key }
+
+    func validate() throws {
+        guard !owner.isEmpty, !key.isEmpty, revision >= 0, characters >= 0,
+              activeMicroseconds >= 0, segments.allSatisfy({ !$0.isEmpty }) else {
+            throw RA1RevisionError.invalidPayload
+        }
+    }
+}
+
+@objc(BigSyncRA1OwnedRevisionObject)
+private final class RA1OwnedRevisionObject: Object, ChangeMetadataRecordable,
+    BigSyncStringEncodedIntegerModel, BigSyncInboundSemanticRecordValidating,
+    BigSyncInboundSemanticReplacementValidating,
+    BigSyncOutboundSemanticObjectValidating, BigSyncRetainsSyncedTombstone {
+    static let bigSyncStringEncodedIntegerPropertyNames: Set<String> = [
+        "stateRevision", "characters", "activeMicroseconds",
+    ]
+    @Persisted(primaryKey: true) var id = ""
+    @Persisted var owner = ""
+    @Persisted var logicalKey = ""
+    @Persisted var stateRevision: Int64 = 0
+    @Persisted var segments: MutableSet<String>
+    @Persisted var characters: Int64 = 0
+    @Persisted var activeMicroseconds: Int64 = 0
+    @Persisted var title = ""
+    @Persisted var createdAt = Date()
+    @Persisted var modifiedAt = Date()
+    @Persisted var explicitlyModifiedAt: Date?
+    @Persisted var isDeleted = false
+    var retainsSyncedTombstone: Bool { true }
+
+    var domain: RA1DomainValue {
+        RA1DomainValue(owner: owner, key: logicalKey, revision: stateRevision,
+                       segments: Set(segments), characters: characters,
+                       activeMicroseconds: activeMicroseconds, title: title,
+                       deleted: isDeleted)
+    }
+
+    func assign(_ value: RA1DomainValue) {
+        owner = value.owner
+        logicalKey = value.key
+        stateRevision = value.revision
+        segments.removeAll()
+        segments.insert(objectsIn: value.segments)
+        characters = value.characters
+        activeMicroseconds = value.activeMicroseconds
+        title = value.title
+        isDeleted = value.deleted
+    }
+
+    static func decode(_ record: CKRecord) throws -> RA1DomainValue {
+        guard record.recordType == className(),
+              let owner = record["owner"] as? String,
+              let key = record["logicalKey"] as? String,
+              let revision = BigSyncStringEncodedIntegerCodec.decode(record["stateRevision"]),
+              let characters = BigSyncStringEncodedIntegerCodec.decode(record["characters"]),
+              let duration = BigSyncStringEncodedIntegerCodec.decode(record["activeMicroseconds"]),
+              let title = record["title"] as? String,
+              let deleted = BigSyncCloudKitBooleanCodec.decode(record["isDeleted"]),
+              record["segments"] == nil || record["segments"] is [String] else {
+            throw RA1RevisionError.invalidPayload
+        }
+        let value = RA1DomainValue(owner: owner, key: key, revision: revision,
+            segments: Set(record["segments"] as? [String] ?? []), characters: characters,
+            activeMicroseconds: duration, title: title, deleted: deleted)
+        try value.validate()
+        guard record.recordID.recordName == className() + "." + value.id else {
+            throw RA1RevisionError.changedIdentity
+        }
+        return value
+    }
+
+    static func validateInboundSemanticRecord(_ record: CKRecord) throws {
+        _ = try decode(record)
+    }
+
+    static func validateInboundSemanticReplacement(
+        _ record: CKRecord, existingObject: Object?
+    ) throws {
+        _ = try inboundSemanticReplacementDisposition(record, existingObject: existingObject)
+    }
+
+    static func inboundSemanticReplacementDisposition(
+        _ record: CKRecord, existingObject: Object?
+    ) throws -> BigSyncInboundSemanticReplacementDisposition {
+        let incoming = try decode(record)
+        guard let existing = existingObject as? RA1OwnedRevisionObject else {
+            return .applyIncomingRecord
+        }
+        let local = existing.domain
+        try local.validate()
+        guard incoming.id == existing.id,
+              incoming.owner == local.owner, incoming.key == local.key else {
+            throw RA1RevisionError.changedIdentity
+        }
+        if incoming.revision > local.revision { return .preferIncomingRecord }
+        if incoming.revision < local.revision { return .preferExistingObject }
+        guard incoming == local else { throw RA1RevisionError.divergentEqualRevision }
+        // Audit timestamps and CK system/transport fields do not change domain equality.
+        return .preserveExistingObject
+    }
+
+    func validateOutboundSemanticObject(in realm: Realm) throws {
+        try domain.validate()
+        guard id == domain.id else { throw RA1RevisionError.changedIdentity }
+        // A foreign-owned unchanged relay is allowed; it is not a new authored read.
+    }
+}
+
+@BigSyncBackgroundActor
+private final class RA1RealmFixture {
+    let adapter: RealmSwiftAdapter
+    let target: Realm
+    let tracking: Realm
+    var journalIdentity: BigSyncMutationJournalIdentity
+    let scope: String
+    let assets: URL
+
+    private init(adapter: RealmSwiftAdapter, target: Realm, tracking: Realm, assets: URL) {
+        self.adapter = adapter
+        self.target = target
+        self.tracking = tracking
+        self.assets = assets
+        self.scope = "ra1-test-account"
+        self.journalIdentity = .init(installationIdentifier: "owner-a",
+            replicaBindingGenerationIdentifier: String(repeating: "a", count: 64))
+    }
+
+    static func make() async throws -> RA1RealmFixture {
+        let nonce = UUID().uuidString
+        var persistence = RealmSwiftAdapter.defaultPersistenceConfiguration()
+        persistence.inMemoryIdentifier = "ra1-tracking-" + nonce
+        var configuration = Realm.Configuration()
+        configuration.inMemoryIdentifier = "ra1-target-" + nonce
+        configuration.objectTypes = [RA1OwnedRevisionObject.self, BigSyncPendingMutation.self]
+        let assets = FileManager.default.temporaryDirectory.appendingPathComponent("ra1-assets-" + nonce)
+        let adapter = RealmSwiftAdapter(persistenceRealmConfiguration: persistence,
+            targetRealmConfigurations: [configuration], excludedClassNames: [],
+            recordZoneID: CKRecordZone.ID(zoneName: "ra1-" + nonce,
+                                         ownerName: CKCurrentUserDefaultName),
+            logger: Logger(label: "OwnedRecordRevisionTests"), startSetupTask: false,
+            assetDirectoryURL: assets)
+        try await adapter.resetSyncCaches()
+        adapter.invalidateTokens() // Tests explicitly forward the real journal, without timer races.
+        let target = try XCTUnwrap(adapter.realmProvider?.targetReaderRealms?.first)
+        let tracking = try XCTUnwrap(adapter.realmProvider?.persistenceRealm)
+        let result = RA1RealmFixture(adapter: adapter, target: target, tracking: tracking, assets: assets)
+        try await result.bind(result.journalIdentity, scope: result.scope)
+        return result
+    }
+
+    func bind(_ identity: BigSyncMutationJournalIdentity, scope: String) async throws {
+        journalIdentity = identity
+        BigSyncMutationPolicy(excludedClassNames: []).install(configurations: [target.configuration],
+            mutationJournalIdentityProvider: { identity })
+        try await adapter.activateTransportNamespace(containerIdentifier: "iCloud.ra1-test", databaseScope: .private)
+        try await adapter.activateReplicaBinding(accountScopeIdentifier: scope,
+            replicaBindingGenerationIdentifier: identity.replicaBindingGenerationIdentifier)
+    }
+
+    func record(_ value: RA1DomainValue, auditTime: TimeInterval = 1_000) -> CKRecord {
+        let record = CKRecord(recordType: RA1OwnedRevisionObject.className(),
+            recordID: .init(recordName: name(value.id), zoneID: adapter.recordZoneID))
+        record["owner"] = value.owner as CKRecordValue
+        record["logicalKey"] = value.key as CKRecordValue
+        record["stateRevision"] = String(value.revision) as CKRecordValue
+        record["segments"] = value.segments.sorted() as CKRecordValue
+        record["characters"] = String(value.characters) as CKRecordValue
+        record["activeMicroseconds"] = String(value.activeMicroseconds) as CKRecordValue
+        record["title"] = value.title as CKRecordValue
+        record["isDeleted"] = value.deleted as CKRecordValue
+        record["createdAt"] = Date(timeIntervalSince1970: 1) as CKRecordValue
+        record["modifiedAt"] = Date(timeIntervalSince1970: auditTime) as CKRecordValue
+        record["explicitlyModifiedAt"] = Date(timeIntervalSince1970: auditTime) as CKRecordValue
+        return record
+    }
+
+    func name(_ id: String = "owner-a|article-a:page-0") -> String {
+        RA1OwnedRevisionObject.className() + "." + id
+    }
+
+    func value(_ id: String = "owner-a|article-a:page-0") throws -> RA1DomainValue {
+        try XCTUnwrap(target.object(ofType: RA1OwnedRevisionObject.self, forPrimaryKey: id)).domain
+    }
+
+    func generation(_ id: String = "owner-a|article-a:page-0") -> String? {
+        target.object(ofType: BigSyncPendingMutation.self, forPrimaryKey: name(id))?.generation
+    }
+
+    func refresh() async {
+        await target.asyncRefresh()
+        await tracking.asyncRefresh()
+    }
+
+    @discardableResult
+    func author(_ value: RA1DomainValue, auditTime: TimeInterval = 1_000) async throws -> String {
+        try await target.asyncWrite {
+            let object = self.target.object(ofType: RA1OwnedRevisionObject.self, forPrimaryKey: value.id)
+                ?? RA1OwnedRevisionObject()
+            if object.realm == nil { object.id = value.id }
+            object.assign(value)
+            if object.realm == nil { self.target.add(object) }
+            _ = try object.refreshChangeMetadata(explicitlyModified: true,
+                at: Date(timeIntervalSince1970: auditTime), expectedJournalIdentity: self.journalIdentity)
+        }
+        return try XCTUnwrap(generation(value.id))
+    }
+
+    func prepared() async throws -> [PreparedRecordUpload] {
+        try await adapter._test_forwardPendingMutations(in: target)
+        return try await adapter.preparedRecordsToUpload(limit: 10, restrictedToEntityType: nil)
+    }
+
+    func nextUpload() async throws -> PreparedRecordUpload {
+        let uploads = try await prepared()
+        XCTAssertEqual(uploads.count, 1)
+        return try XCTUnwrap(uploads.first)
+    }
+
+    func acknowledge(_ prepared: PreparedRecordUpload) async throws {
+        try await adapter.didUpload(savedRecords: [prepared.record],
+            matchingGenerations: [prepared.record.recordID.recordName: try XCTUnwrap(prepared.generation)])
+        await refresh()
+    }
+}
+
+final class OwnedRecordRevisionTests: XCTestCase {
+    private let mark = RA1DomainValue(revision: 42, segments: ["x", "y"], characters: 7)
+    private let undo = RA1DomainValue(revision: 43, segments: [], characters: 0)
+
+    @BigSyncBackgroundActor
+    func testLatePopulatedDownloadRequeuesNewerEmptyValueWithoutReauthoring() async throws {
+        for forceSave in [false, true] {
+            for retainedTombstone in [false, true] {
+                let f = try await RA1RealmFixture.make()
+                var newer = undo
+                newer.deleted = retainedTombstone
+                _ = try await f.adapter.saveChanges(in: [f.record(newer)], forceSave: true)
+                await f.refresh()
+                XCTAssertNil(f.generation())
+                _ = try await f.adapter.saveChanges(in: [f.record(mark, auditTime: 9_000)], forceSave: forceSave)
+                await f.refresh()
+                XCTAssertEqual(try f.value(), newer)
+                XCTAssertNotNil(f.generation(), "Local preference must become ordinary upload work")
+                let upload = try await f.nextUpload()
+                XCTAssertEqual(try RA1OwnedRevisionObject.decode(upload.record), newer)
+                XCTAssertEqual(upload.record["modifiedAt"] as? Date, Date(timeIntervalSince1970: 1_000))
+                try await f.acknowledge(upload)
+                XCTAssertNil(f.generation())
+                XCTAssertEqual(try f.value(), newer, "Acknowledgement must retain the empty/tombstoned version")
+            }
+        }
+    }
+
+    @BigSyncBackgroundActor
+    func testHigherIncomingRevisionReplacesPendingValueAndMintsNewGeneration() async throws {
+        for forceSave in [false, true] {
+            let f = try await RA1RealmFixture.make()
+            let g1 = try await f.author(mark, auditTime: 9_000)
+            let sent = try await f.nextUpload()
+            _ = try await f.adapter.saveChanges(in: [f.record(undo, auditTime: 10)], forceSave: forceSave)
+            await f.refresh()
+            let g2 = try XCTUnwrap(f.generation())
+            XCTAssertNotEqual(g1, g2)
+            XCTAssertEqual(try f.value(), undo)
+            try await f.acknowledge(sent)
+            XCTAssertEqual(f.generation(), g2)
+            let next = try await f.nextUpload()
+            XCTAssertEqual(next.generation, g2)
+            XCTAssertEqual(try RA1OwnedRevisionObject.decode(next.record), undo)
+            try await f.acknowledge(next)
+            XCTAssertNil(f.generation())
+        }
+    }
+
+    @BigSyncBackgroundActor
+    func testOlderOwnEchoAndG1AcknowledgementCannotRetireG2() async throws {
+        for tombstone in [false, true] {
+            let f = try await RA1RealmFixture.make()
+            _ = try await f.author(mark)
+            let sent = try await f.nextUpload()
+            var newer = undo
+            newer.deleted = tombstone
+            let g2 = try await f.author(newer)
+            // Intentionally do not forward G2 before G1 acknowledgement. The target
+            // journal, not the tracking cache's last forwarded generation, is decisive.
+            let results = try await f.adapter.validateAuthoritativeOwnUploadRecords([sent.record])
+            XCTAssertEqual(results.first?.disposition, .validatedAuthoritativeOwnUpload)
+            try await f.acknowledge(sent)
+            XCTAssertEqual(try f.value(), newer)
+            XCTAssertEqual(f.generation(), g2)
+            let pending = try await f.nextUpload()
+            XCTAssertEqual(pending.generation, g2)
+            XCTAssertEqual(try RA1OwnedRevisionObject.decode(pending.record), newer)
+        }
+    }
+
+    @BigSyncBackgroundActor
+    func testClockRevisionThenUndoTransportsNewestCompletePayload() async throws {
+        let f = try await RA1RealmFixture.make()
+        _ = try await f.author(mark)
+        var clock = mark
+        clock.revision = 43
+        clock.activeMicroseconds = 250
+        clock.title = "Updated title"
+        _ = try await f.author(clock)
+        var reversed = clock
+        reversed.revision = 44
+        reversed.segments = []
+        reversed.characters = 0
+        _ = try await f.author(reversed)
+        for older in [mark, clock] {
+            _ = try await f.adapter.saveChanges(in: [f.record(older, auditTime: 99_000)], forceSave: true)
+        }
+        await f.refresh()
+        XCTAssertEqual(try f.value(), reversed)
+        let upload = try await f.nextUpload()
+        XCTAssertEqual(try RA1OwnedRevisionObject.decode(upload.record), reversed)
+        // This tests complete record transport, not Common's inverse or semantic guard.
+    }
+
+    @BigSyncBackgroundActor
+    func testEqualRevisionReplayNormalizesSetsAndIgnoresAuditMetadata() async throws {
+        let f = try await RA1RealmFixture.make()
+        _ = try await f.adapter.saveChanges(in: [f.record(mark)], forceSave: true)
+        let replay = f.record(mark, auditTime: 99_000)
+        replay["segments"] = ["y", "x"] as CKRecordValue
+        replay["createdAt"] = Date(timeIntervalSince1970: 500) as CKRecordValue
+        _ = try await f.adapter.saveChanges(in: [replay], forceSave: true)
+        await f.refresh()
+        XCTAssertEqual(try f.value(), mark)
+        XCTAssertNil(f.generation())
+        XCTAssertTrue(f.tracking.objects(BigSyncInboundSemanticQuarantine.self).isEmpty)
+        let object = try XCTUnwrap(f.target.object(ofType: RA1OwnedRevisionObject.self, forPrimaryKey: mark.id))
+        XCTAssertEqual(object.modifiedAt, Date(timeIntervalSince1970: 1_000))
+    }
+
+    @BigSyncBackgroundActor
+    func testEqualRevisionDivergenceIsQuarantinedWithoutLosingPendingWork() async throws {
+        for forceSave in [false, true] {
+            let f = try await RA1RealmFixture.make()
+            let generation = try await f.author(mark)
+            var different = mark
+            different.activeMicroseconds += 1 // Clock fields are part of complete domain equality.
+            let results = try await f.adapter.saveChanges(in: [f.record(different)], forceSave: forceSave)
+            await f.refresh()
+            XCTAssertEqual(results.count, 1)
+            guard let result = results.first, case .quarantined = result.disposition else {
+                XCTFail("Expected existing semantic quarantine diagnostics")
+                return
+            }
+            XCTAssertEqual(try f.value(), mark)
+            XCTAssertEqual(f.generation(), generation)
+            XCTAssertEqual(f.tracking.objects(BigSyncInboundSemanticQuarantine.self).count, 1)
+            let upload = try await f.nextUpload()
+            XCTAssertEqual(try RA1OwnedRevisionObject.decode(upload.record), mark)
+        }
+    }
+
+    @BigSyncBackgroundActor
+    func testOmittedEmptyMembershipIsTheSameDomainReplay() async throws {
+        let f = try await RA1RealmFixture.make()
+        _ = try await f.adapter.saveChanges(in: [f.record(undo)], forceSave: true)
+        let omitted = f.record(undo, auditTime: 99_000)
+        omitted["segments"] = nil
+        _ = try await f.adapter.saveChanges(in: [omitted], forceSave: true)
+        await f.refresh()
+        XCTAssertEqual(try f.value(), undo)
+        XCTAssertNil(f.generation())
+        XCTAssertTrue(f.tracking.objects(BigSyncInboundSemanticQuarantine.self).isEmpty)
+    }
+
+    @BigSyncBackgroundActor
+    func testChangedOwnerCannotAddressExistingRecordEvenWithHigherRevision() async throws {
+        let f = try await RA1RealmFixture.make()
+        let generation = try await f.author(mark)
+        let forged = f.record(undo)
+        forged["owner"] = "owner-b" as CKRecordValue
+        _ = try await f.adapter.saveChanges(in: [forged], forceSave: true)
+        await f.refresh()
+        XCTAssertEqual(try f.value(), mark)
+        XCTAssertEqual(f.generation(), generation)
+        XCTAssertEqual(f.tracking.objects(BigSyncInboundSemanticQuarantine.self).count, 1)
+    }
+
+    @BigSyncBackgroundActor
+    func testRequiredJournalIdentityFailureRollsBackDomainAndRevision() async throws {
+        let f = try await RA1RealmFixture.make()
+        let beforeGeneration = try await f.author(mark)
+        let differentIdentity = BigSyncMutationJournalIdentity(installationIdentifier: "replacement",
+            replicaBindingGenerationIdentifier: String(repeating: "b", count: 64))
+        BigSyncMutationPolicy(excludedClassNames: []).install(configurations: [f.target.configuration],
+            mutationJournalIdentityProvider: { differentIdentity })
+        do {
+            _ = try await f.author(undo)
+            XCTFail("An identity change must abort the owning Realm write")
+        } catch is BigSyncMutationJournalError { }
+        await f.refresh()
+        XCTAssertEqual(try f.value(), mark)
+        XCTAssertEqual(f.generation(), beforeGeneration)
+    }
+
+    @BigSyncBackgroundActor
+    func testReseedKeepsOriginalOwnerAndRevisionUnderNewJournalIdentity() async throws {
+        let f = try await RA1RealmFixture.make()
+        let originalGeneration = try await f.author(undo)
+        let replacement = BigSyncMutationJournalIdentity(installationIdentifier: "restored-installation",
+            replicaBindingGenerationIdentifier: String(repeating: "b", count: 64))
+        try await f.bind(replacement, scope: f.scope)
+        let epoch = 4_000_000_001
+        try await f.adapter.prepareChangeFeedReset(accountScopeIdentifier: f.scope, epoch: epoch,
+                                                   mode: .localDatasetRebootstrap)
+        try await f.adapter.beginChangeFeedServerBootstrap(accountScopeIdentifier: f.scope, epoch: epoch,
+                                                            mode: .localDatasetRebootstrap)
+        try await f.adapter.reconcileAfterChangeFeedServerBootstrap(accountScopeIdentifier: f.scope,
+                                                                     epoch: epoch, mode: .localDatasetRebootstrap)
+        await f.refresh()
+        XCTAssertEqual(try f.value(), undo)
+        XCTAssertNotEqual(f.generation(), originalGeneration)
+        let pending = try XCTUnwrap(f.target.object(ofType: BigSyncPendingMutation.self,
+                                                   forPrimaryKey: f.name()))
+        XCTAssertEqual(pending.replicaBindingGenerationIdentifier, replacement.replicaBindingGenerationIdentifier)
+        let upload = try await f.nextUpload()
+        XCTAssertEqual(try RA1OwnedRevisionObject.decode(upload.record), undo)
+        // A controlled empty destination tests relay, not admission of a real backup.
+    }
+
+    @BigSyncBackgroundActor
+    func testRealUploadLoopRetriesLowerServerConflictWithNewerLocalEmptyState() async throws {
+        try await exerciseConflictLoop(local: undo, server: mark, expected: undo)
+    }
+
+    @BigSyncBackgroundActor
+    func testRealUploadLoopReplacesStalePendingMarkWithNewerServerEmptyState() async throws {
+        try await exerciseConflictLoop(local: mark, server: undo, expected: undo)
+    }
+
+    @BigSyncBackgroundActor
+    private func exerciseConflictLoop(local: RA1DomainValue, server: RA1DomainValue,
+                                      expected: RA1DomainValue) async throws {
+        let f = try await RA1RealmFixture.make()
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("ra1-transport-" + UUID().uuidString)
+        let io = RA1ScriptedIO(serverConflict: f.record(server, auditTime: 90_000))
+        let store = RA1KeyValueStore()
+        let sync = CloudKitSynchronizer(identifier: UUID().uuidString,
+            containerIdentifier: "iCloud.ra1-test", database: io,
+            recordZoneID: f.adapter.recordZoneID, keyValueStore: store,
+            accountIdentifierProvider: { "ra1-cloud-account" }, accountStatusProvider: { .available },
+            backupDetectionBaseURL: root, logger: Logger(label: "RA1ConflictLoop"))
+        sync.addModelAdapter(f.adapter)
+        // Same actual account/attempt setup used by the existing direct-upload tests.
+        // Only remote IO is scripted; the adapter, journals and admission lease are real.
+        try await sync._test_validateSynchronizationAccount()
+        let account = try XCTUnwrap(store.object(forKey: sync.durableStateKey("CloudKitAccountIdentifier")) as? String)
+        let lease = try XCTUnwrap(sync.accountScopeLease())
+        let binding = try sync.activeReplicaBindingGenerationIdentifierForRun(accountScopeIdentifier: lease.accountScopeIdentifier)
+        let installation = try XCTUnwrap(BackupDetection.installationIdentifier(
+            namespace: sync.durableStateNamespace, sharedSentinelBaseURL: root))
+        try await f.bind(.init(installationIdentifier: installation,
+                              replicaBindingGenerationIdentifier: binding), scope: lease.accountScopeIdentifier)
+        sync.activeRunContext = .init(attemptID: sync.synchronizationAttemptID,
+            runID: sync.synchronizationRunID, accountIdentifier: account,
+            accountScopeIdentifier: lease.accountScopeIdentifier,
+            replicaBindingGenerationIdentifier: binding, accountInvalidationGeneration: lease.invalidationGeneration)
+        _ = try await f.author(local)
+        _ = try await f.prepared()
+        try await sync.synchronizeAdapter(f.adapter)
+        await f.refresh()
+        let uploads = await io.uploadedValues()
+        XCTAssertEqual(uploads, [local, expected])
+        XCTAssertEqual(try f.value(), expected)
+        XCTAssertNil(f.generation(), "Retry must reach real generation acknowledgement")
+        XCTAssertTrue(f.tracking.objects(BigSyncInboundSemanticQuarantine.self).isEmpty)
+        let transport = try sync.outboundQuiescenceSnapshot()
+        XCTAssertTrue(transport.outstandingSubmissions.isEmpty)
+    }
+}
+
+// Deliberately bounded remote script: exactly one serverRecordChanged followed
+// by one successful retry. Unexpected operations throw rather than succeeding.
+private actor RA1MutationScript {
+    let conflict: CKRecord
+    var uploads: [RA1DomainValue] = []
+    init(conflict: CKRecord) { self.conflict = conflict }
+    func modify(_ records: [CKRecord], deleting: [CKRecord.ID],
+                savePolicy: CKModifyRecordsOperation.RecordSavePolicy, atomically: Bool) throws -> CloudKitRecordMutationResults {
+        guard records.count == 1, deleting.isEmpty, !atomically,
+              savePolicy == .ifServerRecordUnchanged, uploads.count < 2,
+              records[0].recordID == conflict.recordID else { throw RA1RevisionError.unexpectedIO }
+        let record = records[0]
+        uploads.append(try RA1OwnedRevisionObject.decode(record))
+        if uploads.count == 1 {
+            let error = NSError(domain: CKErrorDomain, code: CKError.serverRecordChanged.rawValue,
+                userInfo: [CKRecordChangedErrorServerRecordKey: conflict])
+            return .init(saveResults: [record.recordID: .failure(error)], deleteResults: [:])
+        }
+        return .init(saveResults: [record.recordID: .success(record)], deleteResults: [:])
+    }
+}
+
+private final class RA1ScriptedIO: NSObject, CloudKitDatabaseAdapter, CloudKitRecordStore,
+    CloudKitChangeFeed, CloudKitZoneStore, CloudKitSubscriptionStore, @unchecked Sendable {
+    let script: RA1MutationScript
+    var databaseScope: CKDatabase.Scope { .private }
+    init(serverConflict: CKRecord) { script = RA1MutationScript(conflict: serverConflict) }
+    func uploadedValues() async -> [RA1DomainValue] { await script.uploads }
+    func modifyRecords(saving records: [CKRecord], deleting ids: [CKRecord.ID],
+                       savePolicy: CKModifyRecordsOperation.RecordSavePolicy, atomically: Bool) async throws -> CloudKitRecordMutationResults {
+        try await script.modify(records, deleting: ids, savePolicy: savePolicy, atomically: atomically)
+    }
+    func recordZone(withID id: CKRecordZone.ID) async throws -> CKRecordZone { CKRecordZone(zoneID: id) }
+    func save(recordZone: CKRecordZone) async throws -> CKRecordZone { throw RA1RevisionError.unexpectedIO }
+    func deleteRecordZone(withID id: CKRecordZone.ID) async throws { throw RA1RevisionError.unexpectedIO }
+    func subscription(withID id: CKSubscription.ID) async throws -> CKSubscription? { throw RA1RevisionError.unexpectedIO }
+    func save(subscription: CKSubscription) async throws -> CKSubscription { throw RA1RevisionError.unexpectedIO }
+    func deleteSubscription(withID id: CKSubscription.ID) async throws { throw RA1RevisionError.unexpectedIO }
+    func databaseChanges(since cursor: DatabaseChangeCursor?, resultsLimit: Int?) async throws -> CloudKitDatabaseChangePage {
+        throw RA1RevisionError.unexpectedIO
+    }
+    func recordZoneChanges(in id: CKRecordZone.ID, since cursor: RecordZoneChangeCursor?,
+                           desiredKeys: [CKRecord.FieldKey]?, resultsLimit: Int?) async throws -> CloudKitRecordZoneChangePage {
+        throw RA1RevisionError.unexpectedIO
+    }
+}
+
+private final class RA1KeyValueStore: NSObject, KeyValueStore {
+    // The synchronizer accesses its store on BigSyncBackgroundActor.
+    private var values: [String: Any] = [:]
+    func object(forKey key: String) -> Any? { values[key] }
+    func bool(forKey key: String) -> Bool { values[key] as? Bool ?? false }
+    func set(value: Any?, forKey key: String) { values[key] = value }
+    func set(boolValue: Bool, forKey key: String) { values[key] = boolValue }
+    func removeObject(forKey key: String) { values.removeValue(forKey: key) }
+    func synchronize() -> Bool { true }
+}
+#endif


### PR DESCRIPTION
## Worker 2 — first deliverable published, full collapse not complete

Coordinator: aehlke/manabi-reader#21. Exclusive source/test ownership: BigSyncKit only.

- Preserved base: `2a28f8cfa48fa16c471fa4d54c2689f21567905f`.
- Target: `codex/reading-analytics-integration-20260911`.
- Personal branch: `codex/reading-analytics-w2-sync-20260911`.
- Current head: `39f99186874d2fdb4c89732c16b92b2dc0cc8efd`.
- Actual API note: `99c404cf07a19caf76b6b66fd916c40f1e08e674`.
- Real Realm test source: `eefb5d24edc719b9ed009de49b801f44be721064`.

### Published

`Documentation/ReadingAnalyticsRevisionContract.md` explains the existing final-write preferences, forceSave and serverRecordChanged handling, validation-only own echoes, journal requeue, canonical domain equality exclusions, checked nonnegative Int64 revisions, retained empty/tombstone semantics and existing installation/binding APIs. W3 can implement these actual hooks without a new API family.

`Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift` adds **12 methods** using a real Realm model, actual target/tracking Realms, installed strict journals and the actual Realm adapter. Cases include empty/tombstoned revision43 vs late42, ordinary/forceSave imports, newer incoming pending replacement, G1 acknowledgement before G2 forwarding, late own echo, complete clock-inclusive revision44, normalized set/empty replay, divergent equal-version quarantine, immutable owner/key rejection, strict journal rollback and unchanged-ownership reseed.

Two methods execute the actual `CloudKitSynchronizer.synchronizeAdapter` upload/conflict/retry/ack path; only remote IO is scripted. The fixture does not replace Realm, the journal, adapter, account validation or outbound admission. This is transport test source, not Common-model or Mark/Undo implementation qualification.

`Documentation/ReadingAnalyticsWorker2.md` contains exact method IDs for W1's explicit native membership, the removal/retention inventory and current release gates.

### Evidence

DEBUG-defined Swift frontend syntax parse passed. Published test blob `453bfbde493f34d01de977fab97b6c464c6de241` matches independently prepared bytes; SHA-256 `0b4e588d76e5eefd21bc15e5f77dd6e773561bba8e36ce3e590677884c3aec57`.

**Apple typecheck/native execution have NOT run.** No collaborator-only or historical passing suite is counted as current evidence. W1 must register the new file and use the approved native runner. Existing cancellation/account/callback/partial-result regression files are unchanged, not claimed rerun.

### Scope accounting and actual remaining work

**0 new/reimplemented production LOC; 0 production deletions; 562 new test lines; two documentation files; no manifest/workflow or identical source moves.** No adapter patch has been justified by source inspection; the native suite must pass before the version contract is called qualified.

**No cutover API has yet been removed.** W6 Core#7 explicitly still has old orchestration; W8 Core#6 retains actual backup/restore. Their caller-removal SHAs are needed before deleting accepted-head/final-drain/reservation/source-publication/completion APIs. The full 120-line accepted-head and 115-line paused-reservation extensions are identified candidates, not deletions already completed.

Ordinary upload/delete still calls outbound admission and submitted-operation bookkeeping. The mixed quiescence/replay files remain runtime-reachable. Do not blanket-delete them, clear persisted checkpoints or reinterpret physical uncertainty as settled merely to launch RA-1. No new barrier, phase machine, second journal, conditional server-wide Undo or source-publication requirement is introduced.

Keep draft. W1 alone decides dependency-closed integration readiness. No release/default merge, force push, source activation, live CloudKit/user migration, baseline selection, state clearing or Mac worktree changes were performed.