### PR TITLE
[RA-1 W2] Preserve reconciled restore, lease ownership and completion delivery

### DIFF
--- a/Documentation/ReadingAnalyticsRevisionContract.md
+++ b/Documentation/ReadingAnalyticsRevisionContract.md
@@ -1,8 +1,10 @@
 # RA-1: owned-record revision contract
 
-Worker 2 / BigSyncKit. Source inspected: `2a28f8cfa48fa16c471fa4d54c2689f21567905f`.
+Worker 2 / BigSyncKit. Production inspected: `2a28f8cfa48fa16c471fa4d54c2689f21567905f`,
+unchanged through the first integration merge `5923cdccc39d90952865d27041ee7ac1168a1ac8`.
 This is the application-model integration contract for W3, not a new transport API.
 Normal Mark/Undo needs no quiescence acquisition, source activation or publication proof.
+See [Worker 2 status](ReadingAnalyticsWorker2.md) for exact test commits and unrun gates.
 
 ## Existing APIs W3 should implement
 
@@ -27,7 +29,7 @@ All validators are synchronous and read-only. The adapter calls replacement/targ
 selection again inside the actual target write, with the current managed preimage.
 The model must not create journals itself while selecting an inbound winner.
 
-For the same immutable owner and logical record key:
+For the same immutable owner and logical record key, with admitted local state:
 
 | Received version | Disposition |
 | --- | --- |
@@ -69,8 +71,8 @@ ordered domain lists. Empty-collection omission must have one explicit decoding 
 
 BigSync's existing `BigSyncStringEncodedIntegerModel` and
 `BigSyncStringEncodedIntegerCodec` use canonical decimal **Int64** on the wire.
-Use a nonnegative representable revision and checked advancement, or explicitly agree
-another representation with W3. A conceptual UInt64 is not an implicit promise that
+Use a nonnegative representable revision and checked advancement; W3's actual model
+requires positive revisions. A conceptual UInt64 is not an implicit promise that
 Realm or this codec accepts values above Int64.max. Never wrap a revision.
 
 ## How the real adapter handles the preferences
@@ -92,10 +94,22 @@ final target transaction before ordinary pending-local/timestamp selection:
   boundary. No second outbox is added by RA-1.
 - `forceSave: true` forces import consideration, not unconditional server victory.
 
+A local write between candidate selection and application does not defeat an explicit
+model preference. Both winner selection and equal-version divergence must be checked
+against that final preimage, even when the local journal changed in the interval.
+
 The real `CloudKitSynchronizer` upload path receives `serverRecordChanged`, imports
 its server record with `saveChanges(... forceSave: true)`, persists imported changes,
 and uses the ordinary upload loop again. The same preferences therefore govern
 conflict retry, not only ordinary downloads.
+
+Journal forwarding and payload materialization are separate. For the unscoped owned
+records exercised here, tracking may still carry G1 while a retry serializes the
+current target value whose journal has advanced to G2. `didUpload` may acknowledge
+G1 in tracking, but must leave G2 in the target journal and forward it for another
+ordinary upload. Two successful saves of the same selected value are permitted; an
+exact two-request script is not the transport contract. No authored revision changes
+merely because a value needs retransmission.
 
 An authoritative same-process own echo is validation-only via
 `validateAuthoritativeOwnUploadRecords`. Its returned preference is not applied to
@@ -121,6 +135,11 @@ capturing an identity uses the throwing
 Let any error escape the enclosing transaction. Do not call the nonthrowing overload
 and assume an outer `try` makes it atomic.
 
+A second journal failure in one target transaction rolls back earlier objects in
+that transaction. Conversely, a later tracking-Realm failure cannot roll back an
+already committed target-Realm winner. Preserve that value and its journal for
+redelivery; do not implement a compensating downgrade across the two physical files.
+
 Record revision, local Undo semantic guard, and upload journal generation are three
 different values. A clock-only authored edit advances the first and third, not the
 second. Undo restores reading fields, not clocks, old revisions or old generations.
@@ -130,12 +149,24 @@ second. Undo restores reading fields, not clocks, old revisions or old generatio
 A newer empty owned record remains a live version. Do not turn its empty membership
 into a CloudKit hard deletion. A model using `isDeleted` as retained ordered negative
 state must opt into `BigSyncRetainsSyncedTombstone` and validate actual record deletion
-through the existing deletion hook according to its supported domain policy. W3 owns
-that policy; ordinary generic deletion is not indefinite negative-state retention.
+through `BigSyncInboundSemanticDeletionValidating`. The former chooses the outbound
+upsert lane; it does not by itself reject an incoming hard deletion. W3 owns that
+policy; ordinary generic deletion is not indefinite negative-state retention.
 
 Restore/reseed preserves original owner/revision/domain values. A new journal
-installation/binding may transport those unchanged values; it must not turn copied
+installation/binding may transport admitted unchanged values; it must not turn copied
 bytes into a newly authored version or silently admit stale history as current truth.
+
+`localDatasetRebootstrap` and `backupRestore` are different contracts. For models
+implementing `BigSyncRestoredObjectRecovering`, backup preparation withholds copied
+objects before retiring copied pending generations. W3 currently uses the local-only
+`isAwaitingRecoveryEvidence` flag and blocks outbound serialization while it is set.
+A real normal server import can re-admit that exact key through `preferIncomingRecord`,
+even when the unadmitted copy had a higher revision. This is a restore-admission
+policy, not permission to downgrade already admitted revision-ordered state. Absence
+from the restored destination does not authorize republishing the copied object.
+Validation-only own echoes cannot apply that preference or clear the recovery flag.
+
 W8 supplies the explicit baseline/restore admission decisions. No live restore,
 baseline choice, state clearing or migration is authorized by this note.
 
@@ -145,7 +176,9 @@ The source above already provides the required preference APIs. No production ch
 is justified solely by the need for decreasing owned values. The targeted RA-1 suite
 uses a real Realm model, real target/tracking Realms and the actual adapter; remote IO
 may be scripted. Native tests must run on the W1-approved runner. Syntax checks or a
-portable comparator do not qualify the adapter or the actual Common models.
+portable comparator do not qualify the adapter or the actual Common models. The
+scripted records do not carry real server-assigned change tags: conflict dispatch
+coverage is not signed CloudKit conditional-save qualification.
 
 W6/W8 must confirm removal of accepted-head/final-drain/seal/source-publication callers
 before W2 deletes their exported APIs. Ordinary upload currently uses outbound admission

--- a/Documentation/ReadingAnalyticsRevisionContract.md
+++ b/Documentation/ReadingAnalyticsRevisionContract.md
@@ -1,187 +1,169 @@
 # RA-1: owned-record revision contract
 
-Worker 2 / BigSyncKit. Production inspected: `2a28f8cfa48fa16c471fa4d54c2689f21567905f`,
-unchanged through the first integration merge `5923cdccc39d90952865d27041ee7ac1168a1ac8`.
-This is the application-model integration contract for W3, not a new transport API.
-Normal Mark/Undo needs no quiescence acquisition, source activation or publication proof.
-See [Worker 2 status](ReadingAnalyticsWorker2.md) for exact test commits and unrun gates.
+Worker 2 / BigSyncKit. Adapter preferences inspected at
+`2a28f8cfa48fa16c471fa4d54c2689f21567905f` remain unchanged. Reconciled manual
+restore handoff: `95e25ba7119733e0fb91e3ff17a5bd12846d2b55`. See
+[Worker 2 status](ReadingAnalyticsWorker2.md) for actual commits, caller joins and
+unrun qualification. Normal Mark/Undo needs no quiescence, activation or publication proof.
 
-## Existing APIs W3 should implement
+## Existing APIs
 
-A synchronized owned model implements `ChangeMetadataRecordable`, its normal Realm
-primary key, and the existing semantic validation protocols:
+A synchronized owned model implements ChangeMetadataRecordable, its normal Realm
+primary key, and the existing semantic protocols:
 
-- `BigSyncInboundSemanticRecordValidating`: validate the complete received domain
-  payload and its record type/key/immutable owner. Validate bounds before decoding
-  large assets. An unavailable local resource is not corrupt remote data.
-- `BigSyncInboundSemanticReplacementValidating`: implement both
-  `validateInboundSemanticReplacement(_:existingObject:)` and
-  `inboundSemanticReplacementDisposition(_:existingObject:)`. The latter is the
-  winner decision. Delegate both to one model-owned validation/selection function.
-- Use `BigSyncInboundSemanticTargetValidating` instead only when the decision
-  genuinely requires other state in the target Realm. That hook takes precedence
-  over the replacement hook. Do not introduce a readiness graph for owned analytics.
-- `BigSyncOutboundSemanticObjectValidating`: validate the actual local payload
-  before serialization. Unchanged relay/reseed of a foreign-owned version is
-  replication, not permission to change its owner or increment its revision.
+- BigSyncInboundSemanticRecordValidating validates complete received domain values,
+  record type/key/immutable owner and bounded assets. Missing local resources are
+  not corrupt remote data.
+- BigSyncInboundSemanticReplacementValidating implements both validation and
+  inboundSemanticReplacementDisposition. Delegate to one model-owned selector.
+- BigSyncInboundSemanticTargetValidating takes precedence when selection genuinely
+  requires other target-Realm state. It is not a reason for another readiness graph.
+- BigSyncOutboundSemanticObjectValidating validates actual local values before
+  serialization. Foreign unchanged relay is replication, not reauthoring.
 
-All validators are synchronous and read-only. The adapter calls replacement/target
-selection again inside the actual target write, with the current managed preimage.
-The model must not create journals itself while selecting an inbound winner.
+Validators are synchronous and read-only. Replacement/target selection is repeated
+inside the actual target write against its current preimage. Do not journal from
+inside a model's inbound selector.
 
-For the same immutable owner and logical record key, with admitted local state:
+For one immutable owner/key with admitted local state:
 
-| Received version | Disposition |
+| Received value | Disposition |
 | --- | --- |
-| No existing object | `applyIncomingRecord` after full validation |
-| Higher state revision | `preferIncomingRecord` |
-| Lower state revision | `preferExistingObject` |
-| Equal revision and equal normalized domain value | `preserveExistingObject` (replay) |
-| Equal revision and different domain value, or incompatible immutable identity | Throw a model error using `BigSyncInboundSemanticValidationFailure` diagnostics |
+| No local object | Apply validated incoming state. |
+| Greater revision | preferIncomingRecord |
+| Lower revision | preferExistingObject |
+| Equal revision/equal normalized domain | preserveExistingObject |
+| Equal revision/different domain or incompatible identity | Throw existing model semantic-validation failure. |
 
-Do not return `applyIncomingRecord` for a higher-version winner: that permits the
-ordinary timestamp/pending-local policy to make the final choice. Do not use
-`preserveExistingObject` for an older server value that needs repair: preservation
-alone does not create upload work when none exists.
+Do not use applyIncomingRecord for a greater winner: it leaves ordinary timestamp
+and pending-local selection in charge. Do not use preserveExistingObject when a
+lower server value requires repair: that alone does not queue upload work.
 
-A semantic rejection is reported through existing per-record quarantine/disposition
-results. It is not necessarily a thrown failure of the entire `saveChanges` batch.
-Cancellation/resource/admission-unavailable errors retain their operational error
-contract; do not reclassify them as an equal-version conflict.
+Semantic rejection is a per-record quarantine/disposition, not necessarily a thrown
+failure of the entire saveChanges batch. Cancellation, resource and unavailable
+admission errors retain their operational meaning.
 
-## What equality means
+## Equality and revisions
 
-Compare typed, normalized authored domain values. This includes immutable identity,
-revision, reading memberships/facts/counters/classifications, the domain tombstone,
-and every other authored synchronized field on that same record. On Sessions (or
-owned records containing clocks), duration, clock ownership, end state, metadata and
-pace receipts are part of the versioned payload. Those writes advance record revision
-without necessarily invalidating Undo.
+Compare typed authored domain values: identity, revision, coverage/facts/counters,
+classification, domain tombstone and every other authored synchronized field on that
+record. Session clocks, duration, end state, metadata and pace receipts participate in
+record versioning without necessarily advancing Undo's semantic guard.
 
-Exclude CloudKit system fields (record change tag, server creation/modification dates,
-encoded system-field archive), synchronizer transport metadata/device UUID, journal
-generation/binding, and deliberately local-only recovery or presentation fields.
-`modifiedAt`/`explicitlyModifiedAt` are conflict/audit metadata, not a fallback winner
-clock after revision selection. Treat `createdAt` according to its actual model
-meaning: exclude a mere audit field, retain it when it represents domain history.
+Exclude CloudKit system fields/change tags, server audit dates, serialized system
+archives, transport process metadata, journal generation/binding, and intentionally
+local-only recovery/presentation state. modifiedAt/explicitlyModifiedAt never override
+an explicit model-selected revision. createdAt is excluded only when it is mere audit
+metadata rather than domain history.
 
-Compare sets/maps by semantic membership and values, not iteration order, JSON bytes,
-CKAsset paths, or checksums of unordered serialization. Preserve order for genuinely
-ordered domain lists. Empty-collection omission must have one explicit decoding rule.
+Compare sets/maps by membership/values, not traversal order, unordered JSON bytes,
+CKAsset paths or checksums of unordered encoding. Preserve genuine list ordering.
+Define one explicit empty-collection omission rule.
 
-BigSync's existing `BigSyncStringEncodedIntegerModel` and
-`BigSyncStringEncodedIntegerCodec` use canonical decimal **Int64** on the wire.
-Use a nonnegative representable revision and checked advancement; W3's actual model
-requires positive revisions. A conceptual UInt64 is not an implicit promise that
-Realm or this codec accepts values above Int64.max. Never wrap a revision.
+BigSyncStringEncodedIntegerModel/Codec use canonical decimal Int64. Revisions must be
+representable and checked on advancement; actual W3 models require positive revisions.
+Never wrap. Record revision, local semantic guard and upload journal generation are
+three distinct values. Undo restores reading fields, not old revisions or generations.
 
-## How the real adapter handles the preferences
+## Real adapter and upload behavior
 
-`RealmSwiftAdapter.saveChanges(in:forceSave:)` evaluates the model decision in its
-final target transaction before ordinary pending-local/timestamp selection:
+RealmSwiftAdapter.saveChanges(in:forceSave:) validates/selects inside the final write:
 
-- A higher incoming winner bypasses ordinary metadata ordering in `applyChanges`.
-  If stale local upload work exists, the selected payload and a **fresh** journal
-  generation replace it together. An old acknowledgement cannot retire that new work.
-- A preferred local winner with a pending journal preserves that journal and payload.
-  With no pending journal, the adapter calls its internal
-  `journalCurrentValuePreservingChangeMetadata(at:)` in the target transaction.
-  This creates ordinary upload work without incrementing the model's revision,
-  changing its owner, or advancing its modification timestamps.
-- The server record's system fields are retained in tracking storage for subsequent
-  conditional retransmission. Target and tracking Realms are not one physical
-  transaction; the existing redelivery/journal mechanisms remain responsible for that
-  boundary. No second outbox is added by RA-1.
-- `forceSave: true` forces import consideration, not unconditional server victory.
+- A greater incoming winner bypasses metadata ordering. Existing stale local upload
+  work is replaced atomically with the selected payload and a fresh journal generation.
+- A preferred local winner preserves existing pending work. Without a journal, the
+  adapter's internal journalCurrentValuePreservingChangeMetadata creates repair work
+  without changing record ownership, revision or audit dates.
+- Server system fields remain in tracking storage for conditional retransmission.
+  Target/tracking Realms are separate transactions, not one atomic file.
+- forceSave forces consideration, not unconditional server victory.
 
-A local write between candidate selection and application does not defeat an explicit
-model preference. Both winner selection and equal-version divergence must be checked
-against that final preimage, even when the local journal changed in the interval.
+A local change after candidate selection does not defeat an explicit model preference.
+Both winner choice and equal-version divergence use the final transaction preimage.
+serverRecordChanged follows forceSave import, persistImportedChanges and the normal
+upload loop; it uses the same model preferences as ordinary inbound data.
 
-The real `CloudKitSynchronizer` upload path receives `serverRecordChanged`, imports
-its server record with `saveChanges(... forceSave: true)`, persists imported changes,
-and uses the ordinary upload loop again. The same preferences therefore govern
-conflict retry, not only ordinary downloads.
+Journal forwarding can lag payload materialization. Tracking G1 may prepare the
+current payload while target journal G2 is newer. Acknowledging G1 must preserve and
+forward G2; another idempotent upload is valid. No authored version advances solely
+for retransmission. An exact two-request test script is not the transport contract.
 
-Journal forwarding and payload materialization are separate. For the unscoped owned
-records exercised here, tracking may still carry G1 while a retry serializes the
-current target value whose journal has advanced to G2. `didUpload` may acknowledge
-G1 in tracking, but must leave G2 in the target journal and forward it for another
-ordinary upload. Two successful saves of the same selected value are permitted; an
-exact two-request script is not the transport contract. No authored revision changes
-merely because a value needs retransmission.
+validateAuthoritativeOwnUploadRecords is validation-only. It cannot apply its returned
+preference, rewrite values or clear restore flags. A late lower-version echo against
+admitted newer state is valid old input, not necessarily corruption. didUpload uses
+the prepared generation, never a fresh sample. Process echo metadata is not record
+installation ownership.
 
-An authoritative same-process own echo is validation-only via
-`validateAuthoritativeOwnUploadRecords`. Its returned preference is not applied to
-rewrite the target. A late lower-version own echo must be valid historical input,
-not a semantic conflict merely because the current target is newer. A mutation result
-is acknowledged separately by `didUpload(savedRecords:matchingGenerations:)` using the
-prepared generation, never a newly sampled one. Echo detection is process metadata,
-not a domain installation-ownership check.
+## Authored transaction boundary
 
-## Local authored transaction boundary
+Capture/recheck the existing BigSyncClientIdentity/BigSyncMutationJournalIdentity.
+In one owning Realm transaction validate the application guard/owner/lifetime, change
+domain values, advance record revision, and require the journal. Ordinary writes use
+refreshChangeMetadataRequiringJournal; identity-bound commands use the throwing
+refreshChangeMetadata(explicitlyModified:at:expectedJournalIdentity:) overload.
+A nonthrowing refresh inside an outer try does not establish rollback semantics.
 
-Use the existing installation/binding APIs, including `BigSyncClientIdentity` and
-`BigSyncMutationJournalIdentity`. A prepared command retains/rechecks its original
-identity. In the same owning Realm write:
+Failure of a second required journal rolls back earlier changes in that same target
+transaction. A tracking-Realm failure after the target commit cannot roll that earlier
+commit back. Keep its selected value/journal for replay; do not compensate to stale state.
 
-1. Validate the application's owner/lifetime/semantic guard.
-2. Change the domain fields and advance the owned record revision.
-3. Require the throwing journal refresh.
+## Empty state and incoming deletion
 
-Ordinary writers use `try refreshChangeMetadataRequiringJournal(at:)`. A command
-capturing an identity uses the throwing
-`refreshChangeMetadata(explicitlyModified:at:expectedJournalIdentity:)` overload.
-Let any error escape the enclosing transaction. Do not call the nonthrowing overload
-and assume an outer `try` makes it atomic.
+A newer empty record remains a live version. Do not hard-delete it merely because it
+has no coverage. BigSyncRetainsSyncedTombstone chooses the retained outbound-upsert
+lane; it does not itself reject inbound hard deletion. Models also implement the
+existing BigSyncInboundSemanticDeletionValidating according to their domain policy.
+Ordinary generic deletion is not an indefinite negative-state guarantee.
 
-A second journal failure in one target transaction rolls back earlier objects in
-that transaction. Conversely, a later tracking-Realm failure cannot roll back an
-already committed target-Realm winner. Preserve that value and its journal for
-redelivery; do not implement a compensating downgrade across the two physical files.
+## Raw backup versus reconciled manual restore
 
-Record revision, local Undo semantic guard, and upload journal generation are three
-different values. A clock-only authored edit advances the first and third, not the
-second. Undo restores reading fields, not clocks, old revisions or old generations.
+localDatasetRebootstrap and backupRestore are different contracts. For recovering
+models, backupRestore withholds copied objects before retiring copied generations.
+Its exception is an existing journal from the current installation/binding. The
+isAwaitingRecoveryEvidence flag alone does not preserve independently known state
+through a later backup-preparation pass.
 
-## Empty state, deletion and restore
+W3 correction848b3f26 validates versions/domain even for a withheld copy: lower server
+input cannot authorize either downgrading it or re-uploading greater unproven bytes;
+it reports unavailable admission. Equal-divergent input rejects. Equal valid or greater
+normal server input can use actual application to re-admit that key. Own-echo validation
+cannot do so. The older BigSync test fixture deliberately exercises a more permissive
+restore selector; it is transport coverage, NOT qualification of this Common policy.
 
-A newer empty owned record remains a live version. Do not turn its empty membership
-into a CloudKit hard deletion. A model using `isDeleted` as retained ordered negative
-state must opt into `BigSyncRetainsSyncedTombstone` and validate actual record deletion
-through `BigSyncInboundSemanticDeletionValidating`. The former chooses the outbound
-upsert lane; it does not by itself reject an incoming hard deletion. W3 owns that
-policy; ordinary generic deletion is not indefinite negative-state retention.
+For W8's actual original-versus-backup normalization, BigSync95e25ba7 provides
+withReconciledManualBackupRestore(transactionIdentifier:configurations:reconciledObjectTypes:_:rollback:).
+Under the existing exclusive lease, the caller installs the final files, with copied-only
+rows withheld and independently validated current rows admitted. The helper publishes the
+new sentinel/binding, then queues admitted values through the existing journal without
+reauthoring them, before releasing the existing restore intent. Current-identity journal
+recognition therefore preserves those known values through the real backupRestore pass.
 
-Restore/reseed preserves original owner/revision/domain values. A new journal
-installation/binding may transport admitted unchanged values; it must not turn copied
-bytes into a newly authored version or silently admit stale history as current truth.
+Register the existing policy/live provider before this call. Do not prepare installation
+inside its locked finalizer. Pass only final target configurations and explicitly
+normalized concrete types. The helper does not establish provenance, choose history,
+normalize raw backup flags or replace W8's physical journal/rollback implementation.
+W3/W8 must bind it instead of a raw restore followed by unconditional normalization.
 
-`localDatasetRebootstrap` and `backupRestore` are different contracts. For models
-implementing `BigSyncRestoredObjectRecovering`, backup preparation withholds copied
-objects before retiring copied pending generations. W3 currently uses the local-only
-`isAwaitingRecoveryEvidence` flag and blocks outbound serialization while it is set.
-A real normal server import can re-admit that exact key through `preferIncomingRecord`,
-even when the unadmitted copy had a higher revision. This is a restore-admission
-policy, not permission to downgrade already admitted revision-ordered state. Absence
-from the restored destination does not authorize republishing the copied object.
-Validation-only own echoes cannot apply that preference or clear the recovery flag.
+Its requirement marker is stored in the existing intent/event/receipt, so a raw retry
+cannot skip repair after a crash. Failed post-event work retains handoffPending and the
+same transaction; no rollback of installed files is authorized. Completed intent cleanup
+retries without repeating file replacement. No second outbox, floor registry, restore
+mode, cloud mutation service or publication protocol is introduced. Existing raw restore
+entry points remain for their own contract; mismatched restore contracts reject rather
+than silently reinterpret an in-flight transaction.
 
-W8 supplies the explicit baseline/restore admission decisions. No live restore,
-baseline choice, state clearing or migration is authorized by this note.
+No real-user baseline selection, live restore or state clearing is authorized here.
 
 ## Qualification and removal boundary
 
-The source above already provides the required preference APIs. No production change
-is justified solely by the need for decreasing owned values. The targeted RA-1 suite
-uses a real Realm model, real target/tracking Realms and the actual adapter; remote IO
-may be scripted. Native tests must run on the W1-approved runner. Syntax checks or a
-portable comparator do not qualify the adapter or the actual Common models. The
-scripted records do not carry real server-assigned change tags: conflict dispatch
-coverage is not signed CloudKit conditional-save qualification.
+No production adapter change is needed solely for decreasing owned values. The authored
+suite uses actual Realm/journal/adapter code; only remote IO and existing boundary hooks
+are controlled. It is not the actual Common inverse or native app. Scripted records have
+no real server change tags. Native tests and the full physical restore/bootstrap journey
+remain unrun; no compiler/test execution occurred in the production coding passes.
 
-W6/W8 must confirm removal of accepted-head/final-drain/seal/source-publication callers
-before W2 deletes their exported APIs. Ordinary upload currently uses outbound admission
-and submitted-operation uncertainty bookkeeping; those are not an Undo dependency and
-must not be removed by filename. Existing persisted physical uncertainty is never
-silently cleared or interpreted as settled.
+W6/W8 must close accepted-head/final-drain/seal/source/completion callers before W2 deletes
+those exports. Ordinary outbound admission, real submitted-operation uncertainty, replay,
+account/binding fencing and generation-matched acknowledgement remain. Existing physical
+checkpoints must never be silently cleared or relabeled settled. An unapplied deletion
+patch is not runtime removal or proof that a cross-repository batch is dependency-closed.

--- a/Documentation/ReadingAnalyticsWorker2.md
+++ b/Documentation/ReadingAnalyticsWorker2.md
@@ -1,105 +1,84 @@
-# RA-1 Worker 2 — actual implementation and remaining joins
+# RA-1 Worker 2 — published code and remaining removal boundary
 
-## Published source
+## Source and ownership
 
-PR #10 merged normally at `5923cdccc39d90952865d27041ee7ac1168a1ac8`.
-PR #11 continues on `codex/reading-analytics-w2-review-20260911`, targeting
-`codex/reading-analytics-integration-20260911`. Coordinator: root issue #21.
-Only W1 merges integration batches; W2 does not modify completed milestone branches.
+PR #10 merged at `5923cdccc39d90952865d27041ee7ac1168a1ac8`. PR #11 continues on
+`codex/reading-analytics-w2-review-20260911`, targeting the dedicated integration
+branch. W2 edits BigSync only; W1 alone approves/merges integration and root pins.
+Latest production checkpoint: **634aed9f2ff52a39275f11004a909be3deea0599**.
 
-| Commit | Implemented change |
+| Commit | Actual implementation |
 | --- | --- |
-| `7b5183b4e38320af92ce9817fc990936f0cc2ca0` | Save/delete drain completions are delivered outside operation catches, preventing downstream errors from causing a second delivery. |
-| `3cbed7cd89f9413ab2d03fe765a95013fbad8950` | Apply that separation through upload composition and zone lookup/creation; a consumer error is not zone-loss evidence. |
-| `33e72a7500d0d7e13b7d827f68a0442c107b7a83` | Revalidate original run/account on zone failures; require the fetched zone identity to match. |
-| `95e25ba7119733e0fb91e3ff17a5bd12846d2b55` | Reconciled manual restore queues unchanged known records under the new identity before releasing its existing durable intent. Completed intent cleanup is retryable without repeating replacement. |
+| 7b5183b4 / 3cbed7cd | Deliver save/delete/upload/zone completions outside operation catches; a throwing consumer is not a second result or zone-loss evidence. |
+| 33e72a75 | Original account/run revalidation on failed zone IO; fetched zone identity must match. |
+| 95e25ba7 | Reconciled manual restore uses existing current-identity repair journals before intent release; completed-but-unremoved intent retries cleanup only. |
+| 634aed9f | Reject nested lease downgrades/restores; validate complete manual event bytes; require reconciled completion for identity admission and event acknowledgement independently of the optional intent file. |
 
-The latest restore commit changes four paths: BackupDetection, BigSyncClientIdentity,
-SyncedEntityProtocol, and a 104-line Realm-specific handoff extension. It does not
-modify RealmSwiftAdapter, introduce another restore mode, or change revision ordering.
+## Reconciled restore: actual caller join exists
 
-## Concrete restore defect and correction
+`BigSyncClientIdentity.withReconciledManualBackupRestore(transactionIdentifier:
+configurations:reconciledObjectTypes:_:rollback:)` is the concrete Realm extension.
+It uses the existing exclusive identity lease and durable manual intent/event/receipt.
+The caller installs final copies reconciled against preserved originals: independently
+known current rows are admitted; backup-only rows remain withheld. After publishing the
+new sentinel/binding, the helper validates admitted rows and journals their unchanged
+values before completing the handoff. It does not change owner, stateRevision, payload
+or audit timestamps. The existing backupRestore adapter preserves current-identity
+journals, so a known empty43 stays admitted/repairable against stale42.
 
-W8's final-copy normalizer can correctly preserve independently current empty A@43
-against backup A@42, setting known43 awaiting=false and copied-only rows awaiting=true.
-But the existing `.backupRestore` preparation calls retainForRestoreRecovery again
-unless a record already has a journal generation in the current installation/binding.
-The flag alone is therefore not sufficient to preserve known43 through that later step.
+The earlier missing-caller report is obsolete:
+- W8 Common **190d5d5d5ad5ec510086c1e4aa57a76c8f64508d**, ReadingAnalyticsManualRestore,
+  registers the live journal provider, invokes this API, validates final installed
+  copies without reflagging known rows, and rebinds the local guard after the actual
+  returned receipt/current identity.
+- W8 Core **0296c8c4620d66d4b47974368d52916c8176415f** calls that Common method from
+  the real UserDataBackupManager.resumeRestore production path.
+- W3 Common **9dccf505cf2799f94ac0a4538b235708f6a9686c**, policy blob27481a93,
+  delegates its stable-ID replacement overload to the same real W8 method and removes
+  the obsolete blanket normalizer. These owner branches still need W1 composition;
+  source binding is not an executed physical restore qualification.
 
-The correction uses that existing current-identity journal exception. The new API is:
+Pass final installed configurations and concrete reconciled model types, not originals
+or staged files. Register the existing live provider before calling; never prepare a
+new installation from inside the replacement/finalizer. Required schema, model,
+identity and journal failures throw. A post-event failure retains handoffPending and
+the caller's physical journal; it does not authorize rollback to the old files.
+Automatic/raw backup restoration still withholds copied state. No second journal,
+restore mode, record-floor registry, cloud save API or blanket admission was added.
 
-```swift
-BigSyncClientIdentity.withReconciledManualBackupRestore(
-    transactionIdentifier: UUID,
-    configurations: [Realm.Configuration],
-    reconciledObjectTypes: [Object.Type],
-    _ replacement: () throws -> Void,
-    rollback: () throws -> Void = {}
-) throws -> BigSyncManualBackupRestoreReceipt
-```
+## Latest source review corrections
 
-The actual sequence is: existing exclusive identity lease and durable intent; caller
-installs/normalizes final files; publish the new sentinel and replica binding; validate
-and journal admitted rows as unchanged repairs; persist the existing completion receipt;
-remove the intent. Only then may ordinary startup resume.
+The recursive registry mutex allowed read-only identity inspection, but also allowed
+retainShared to downgrade the outer exclusive file lease or a nested withExclusive
+defer to release it. Both mutating reentry paths now throw restoreInProgress before
+altering that lease. Read-only current identity remains usable by the existing
+finalizer. This uses the same mutex/file lease, not another lock coordinator.
 
-The journal changes transport attribution, not record owner, stateRevision, payload or
-audit dates. The adapter's existing backupRestore preparation retains those generations
-and their admitted records. Lower server versions then use the normal model preference;
-backup-only records remain withheld. Automatic/raw restoration remains conservative.
+Manual restore event identity previously accepted only a header and UUID, even when
+the full receipt was truncated or its required contract unknown. Event decoding now
+uses the same full receipt parser; old complete raw receipts and automatic UUID events
+retain their format. Malformed manual data is not treated as absence or automatic
+recovery permission.
 
-Required repair work is recorded as an optional requirement in the existing manual
-intent/event/completion receipt. Six-line old receipts still decode unchanged. A new
-reconciled receipt has one required marker; unknown shapes reject. A raw caller cannot
-resume a reconciled transaction and silently skip repair. The existing event identifier
-and public receipt identity remain unchanged.
+Reconciled journal completion is a requirement of the event itself. A missing intent
+file no longer bypasses matching completed-receipt checks in prepareInstallation,
+currentInstallationIdentifier or markRestoreResetCompleted. The event check also
+requires the expected new sentinel. Failure leaves the state pending; no file-clearing
+operation or user restore was executed during this coding pass.
 
-A repair failure after event publication keeps the same durable intent and returns
-handoffPending. Partial per-Realm journal work can retry; it cannot become permission
-to roll back installed files. A completed receipt with failed intent cleanup retries
-cleanup only, not replacement or repair. Restore-event acknowledgement cannot bypass
-an unfinished reconciled handoff. There is no new journal, floor registry, cloud
-publication, general phase machine, or unconditional restore-admission flag.
+## Revision APIs and test source
 
-## Required application binding — not claimed finished
-
-W3 owns BigSyncCloudKitPolicy; W8 owns the real comparison/physical replacement.
-Both ends must be composed. At reviewed Common b4846243, policy still called the raw
-manual restore and old unconditional copy normalizer, and installed journaling only
-after the receipt. The new helper alone does not fix that unmodified application path.
-Exact instructions were posted to Common #7 comment5642314851 and Core #6 comment5642294934.
-
-Before invoking the reconciled overload, register the already-existing mutation policy
-with identity.makeMutationJournalIdentityProvider(). Registration itself does not publish
-identity. Do not call prepareInstallation/installMutationTracking from inside the locked
-finalizer; those paths correctly reject a pending intent and may reacquire the lease.
-The helper requires that registered live provider to match the new identity.
-
-Pass final installed configurations, not staged or original files. Pass only concrete
-model types actually normalized against preserved originals by W8. They must implement
-BigSyncRestoredObjectRecovering, outbound validation and ChangeMetadataRecordable.
-The last normalizer must preserve known=false versus copied=true; do not run the old
-blanket retainForRestoreRecovery over these rows after comparison. Sessions require W5's
-real recoverable conformance, not a cast that silently skips them. Missing schema,
-registration, identity or model validation throws, rather than granting completion.
-
-The caller's existing replacement journal must retain originals and the exact transaction
-on handoffPending. Its replacement closure is idempotent for already-installed files.
-Guard rebinding and process receipt clearing belong to W4/W8's real restore completion,
-not to BigSync's record transport. No actual user restore or history selection was run.
-
-## Revision APIs and existing test source
-
-The existing preferIncomingRecord/preferExistingObject hooks and strict journals are
-unchanged. See [ReadingAnalyticsRevisionContract.md](ReadingAnalyticsRevisionContract.md).
-Test implementation e8b899e57cf5493eca82c4598e449c2bafb08c44, blob
-e14062aeaa9ce1edb164fde2503993765eab5b6e, remains unchanged in the coding passes.
-It uses real Realm/journal/adapter implementations and two actual synchronizeAdapter
-conflict loops. Only remote IO and existing boundary/identity-failure hooks are controlled.
-The model is not Common, and scripted records have no actual server change tags.
+Existing preferIncomingRecord/preferExistingObject, strict journaling, target-write
+revalidation and generation-matched acknowledgements remain unchanged. See
+[ReadingAnalyticsRevisionContract.md](ReadingAnalyticsRevisionContract.md).
+The existing native fixture is real Realm/journal/adapter code, not Common's models.
+Two tests call the real synchronizeAdapter loop with scripted remote IO. Scripted
+records have no real server-assigned change tags. The older fixture's permissive
+backup selector is not W3's corrected restore-admission policy.
 
 Already-registered file: Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift.
-Exact 21 native method IDs:
+Test implementation e8b899e57cf5493eca82c4598e449c2bafb08c44, blobe14062ae,
+is unchanged by the production coding passes. Exact 21 native methods:
 
 ```text
 OwnedRecordRevisionTests/testLatePopulatedDownloadRequeuesNewerEmptyValueWithoutReauthoring
@@ -125,54 +104,49 @@ OwnedRecordRevisionTests/testIncomingHardDeletionCannotEraseAcknowledgedEmptyRev
 OwnedRecordRevisionTests/testBackupRestoreWithholdsCopiedRowsUntilActualServerImport
 ```
 
-These tests cover adapter backup admission, not the newly added reconciled manual
-file-handoff helper. Qualification must compose W8's physical replacement with actual
-BigSync backupRestore and a later server42, plus interrupted repair/cleanup retries.
-No tests, compiler/typecheck, syntax checks, native tooling or CloudKit operations were
-run in the two production coding passes. Earlier parsing evidence is historical and
-must not be applied to these changes. Only preimage/postimage hashes, diffs and GitHub
-publication identities were inspected for safe source publication.
+No tests, compiler/typecheck, syntax checks, native tools or CloudKit ran in this pass.
+Only source/blob/diff and GitHub publication integrity were inspected. Earlier syntax
+results do not apply to new production code. Native qualification must exercise the
+bound physical restore -> adapter backupRestore -> late42 path, interrupted repair,
+missing/malformed handoff records and reentrant preparation, as well as the preserved
+account/cancellation/partial-outcome suites. None is claimed passed or newly authored.
 
-## Cutover removal: actual code dependency remains
+## Remaining code removal is caller-dependent
 
-Current inspected W6 Core #7 still retains ReaderOrderedV2BigSyncTransport and old
-startup/cutover callers. W8 has begun retiring owned orchestration files, but complete
-caller-removal SHAs for BigSync's exported cutover family have not been supplied.
-Removing mutation UI does not close those calls. No export or old authority family
-is falsely reported as removed in this PR.
+Live W6 Core #7 still at1fa7174e retains ReaderOrderedV2BigSyncTransport and old
+startup/cutover callers. W8/W3 source retirement is not complete closure of those
+exported calls. The repeated coordinator request names the actual APIs; no false
+compatibility alias or disabled check is used to pretend they disappeared.
 
-| Surface | Disposition |
+| Surface | Remaining action |
 | --- | --- |
-| AcceptedHeadQuiescence / PausedOutboundRecovery | Exact 120/115-line source deletion patch prepared separately, not applied while callers remain. Exclusive probes/test and manifest references need closure in the same batch. |
+| AcceptedHeadQuiescence / PausedOutboundRecovery | Apply prepared120/115-line deletions only with caller closure and their exclusive probe/script/manifest references. |
 | OutboundCompletion | Remove source-publication wrappers with callers; distinguish supported external-owner recovery. |
-| Synchronizer OutboundQuiescence | Mixed final-drain/source exports and ordinary principal/admission/submission handling. No blanket deletion. |
-| Persistent outbound coordinator / replay | Retain current decoding, outstanding submissions, exact operation identity, generation-matched handling and unknown outcomes. Existing barriers are not automatically settled. |
-| RecordStore / RecordMutations / journals / identity / preferences | Retain ordinary synchronization safety. |
+| Synchronizer OutboundQuiescence | Separate final-drain/source exports from ordinary principal/admission/submission functions. |
+| Persistent outbound coordinator / replay | Keep existing checkpoint decoding, uncertain submissions, original operation identity and generation-matched reconciliation. |
+| RecordStore / RecordMutations / journals / identity / preferences | Retain general synchronization safety. |
 
-Ordinary save/delete still reaches admitOutboundBatch and modifyRecordsHoldingOutboundLease.
-Their physical submission bookkeeping is not an Undo protocol. A missing proxy, empty
-journal, expired timeout, unavailable old provider or lost lock is not settlement.
-The pending two-file source patch is only a first removal slice, not a completed mixed
-runtime collapse or a dependency-closed test/manifest batch. W1/W6/W8 must authorize
-its application after actual calls disappear. No successful compatibility alias exists.
+Ordinary save/delete still invokes admitOutboundBatch and
+modifyRecordsHoldingOutboundLease. No old checkpoint is cleared/reinterpreted as
+settled. The235-line source patch in the prior handoff is unapplied, only a first
+slice, not the entire mixed-code cleanup and not counted as production deletion.
+No cutover export was removed in this latest commit. W6/W8 caller-closure evidence
+remains required before that dependency-closed W2 batch can be published.
 
-## Accounting and next boundaries
+W1 excluded cloud baseline election/CAS/publication; W8 withdrew its raw-save API
+request. Explicit selected local input suffices for isolated composition. Production
+multi-install baseline distribution remains a release decision, not another W2 API.
 
-Restore coding delta vs d664de02: **+201/-20 production**, four files, including one
-104-line new helper; no test changes, no identical moves, no manifest/workflow changes.
-Cumulative PR #11 production delta: **+304/-100**, including the prior two-file callback
-fix. Prior test refinement remains +314/-6; documentation and unapplied patch preparation
-are separate. The 235 prepared source deletions are NOT counted as runtime reduction.
-SwiftPM's existing source discovery includes the helper; actual app composition remains
-W1-owned. No cap increase or scope expansion is implied by this supported restore fix.
+## Accounting and completion boundary
 
-W1 excluded cloud baseline election/CAS/publication in comment5641950120; W8 withdrew
-its create-only API request in5641954172. Explicit selected local input is sufficient
-for isolated composition; production multi-install baseline policy remains separate.
-No raw-bootstrap save API or another transport family was added.
+Latest production delta vs0e7c9f1e: **+53/-17**, two existing files, no new API/file/model,
+framework, source move, test or manifest change. Cumulative PR#11 production vs5923:
+**+357/-117** across six source files (including the earlier104-line restore helper).
+Prior test refinement+314/-6 is unchanged; docs and prepared-but-unapplied deletions
+are separate. No cap increase is implied.
 
-Remaining: W3/W8's actual reconciled restore caller binding; W6/W8's cutover caller
-closure and resulting export/probe removal; W1-approved native and composed qualification.
-Published code is not an integrated app or release authorization. No release/default
-merge, forced ref, live migration, account/zone/journal clearing, source activation,
-foreign-source edit or protected Mac worktree operation was performed.
+Published independent W2 corrections and actual application restore bindings are now
+identified. Export/probe removal is still unfinished coding, not merely a test gate.
+W1 owns exact source composition, native qualification and release authorization.
+No integration/default/release merge, force push, live migration/baseline choice,
+account/zone/journal clearing, production activation or foreign/Mac-worktree edit.

--- a/Documentation/ReadingAnalyticsWorker2.md
+++ b/Documentation/ReadingAnalyticsWorker2.md
@@ -1,66 +1,70 @@
-# RA-1 Worker 2 — revision review and remaining collapse boundary
+# RA-1 Worker 2 — implementation and remaining integration boundary
 
-## Status and revisions
+## Current production work
 
-PR #10 was merged normally by W1 at `5923cdccc39d90952865d27041ee7ac1168a1ac8`.
-This continuation does not modify that completed milestone branch. The existing
-production preferences remain unchanged; native qualification and cutover removal
-are NOT complete. Do not label authored tests as executed behavior.
+PR #10 merged normally at `5923cdccc39d90952865d27041ee7ac1168a1ac8`.
+PR #11 continues on `codex/reading-analytics-w2-review-20260911`, targeting
+`codex/reading-analytics-integration-20260911`. Coordinator: root issue #21.
+The completed milestone branch and integration refs are not edited by W2.
 
-- Production input: `2a28f8cfa48fa16c471fa4d54c2689f21567905f`.
-- Continuation base: `5923cdccc39d90952865d27041ee7ac1168a1ac8`.
-- Work branch: `codex/reading-analytics-w2-review-20260911`.
-- Target: `codex/reading-analytics-integration-20260911`.
-- Coordinator: https://github.com/aehlke/manabi-reader/issues/21 .
-- Revised test commit: `e8b899e57cf5493eca82c4598e449c2bafb08c44`.
-- Revised test blob: `e14062aeaa9ce1edb164fde2503993765eab5b6e`.
-- Test SHA-256: `7472ad3235f64f8b862ab8675258d5b2fe76155d2d7bcb9b59083750fa3de8c3`.
-- API clarification commit: `501f62791c0fd18295c3d2af0cf94accc9c784db`,
-  [ReadingAnalyticsRevisionContract.md](ReadingAnalyticsRevisionContract.md).
+Code-first continuation after `9185ef1d3ba488a7b4febcace4249f79b6d791bb`:
 
-## Findings and refinements
+| Commit | Implemented change |
+| --- | --- |
+| `7b5183b4e38320af92ce9817fc990936f0cc2ca0` | Record save/delete drain wrappers capture only the operation error and call their completion outside the operation catch. |
+| `3cbed7cd89f9413ab2d03fe765a95013fbad8950` | Upload composition and zone setup likewise separate downstream completion failures from operation failures; remove the nested upload catch that redelivered completion. |
+| `33e72a7500d0d7e13b7d827f68a0442c107b7a83` | Revalidate zone-fetch and zone-save failures before lifecycle writes; verify the returned zone identity before recording establishment. |
 
-1. The original conflict script required exactly two uploads. Source permits a
-   target G2 journal to outrun tracking G1: a retry can serialize the selected
-   current payload while acknowledging only G1, then drain the surviving G2.
-   The script now permits one conflict and at most two successful saves. Every
-   retry must contain the selected complete value and the final journal must drain.
-   A separate test explicitly freezes forwarding and asserts G1/G2 behavior without
-   fixture forwarding between preparation and acknowledgement. This is a corrected
-   harness assumption, not a native-reproduced production failure.
-2. The original conflict fixture authored owner-a under a random synchronizer
-   installation. The test author now checks owner equality. Conflict setup uses
-   actual inbound replication plus lower-version repair to queue a foreign value
-   unchanged. It does not relabel ownership or invent an authored revision.
-3. Local-dataset reseeding is not backup restoration. The real Realm test model now
-   implements the existing restore interface and local-only recovery flag, matching
-   W3's admission policy. Actual backupRestore preparation/bootstrap/reconciliation
-   is tested with absent, older, equal and newer server records. Validation-only own
-   echoes must not clear copied-state admission; normal import may re-admit it.
-4. Retained tombstone upserts do not themselves reject incoming hard deletions.
-   The fixture now implements the existing deletion validator, and a test checks
-   acknowledged empty/live and empty/tombstone state survives actual deletion input
-   and still repairs a subsequently received older positive version.
-5. New tests cover final-write selection races, equal-version divergence hidden by
-   a new pending journal, failure on the second required winner journal in one
-   target transaction, and failure between target and tracking Realm commits.
-   The former rolls back both target objects; the latter preserves the committed
-   winner and its journal for replay. No compensating downgrade is introduced.
+The source defect was `do { operation; completion(nil) } catch { completion(error) }`.
+A throwing consumer could receive a second result; zone setup could misinterpret a
+consumer's error as a failed zone operation. Each repaired wrapper now delivers
+one result. A completion error propagates to its caller rather than recursively
+invoking that completion or turning it into zone-loss evidence.
 
-The model is not Common. The suite uses real Realm objects, target/tracking Realms,
-registration, journals, adapter application, serialization and acknowledgements.
-Only remote IO and existing scheduling/identity-failure hooks are controlled. The
-clock case transports an explicitly supplied complete payload; it does not test
-Common's Undo delta. Backup cases do not replace real Realm files or exercise the
-manual restore handoff. Scripted CKRecords have no real server change tags, so these
-are not CloudKit CAS or signed multidevice tests.
+Failed remote IO also suspends. Zone-fetch failure now revalidates the original
+attempt/account before inspecting the active context. Failed zone creation
+revalidates the captured run before classifying the original error. A mismatched
+fetched zone is not establishment evidence. These checks use existing APIs.
 
-## Native test membership
+Final production blobs:
+- RecordMutations: `cc4e76eeb76e3115d962d9a2a0b015c480df7fe2`.
+- Sync: `69dc38a2ed0f8613f77bfff3a68566383c1d3914`.
 
-The same file remains `Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift`; W1's
-root registration for #10 covers it when this revision is selected. No new manifest
-entry is needed, but native discovery and execution remain required. There are now
-21 methods, not 12:
+Exactly two existing production files changed: **+103/-80 (net +23)** relative to
+9185ef1d. There is no new API, model, framework, phase, ledger, source move,
+manifest change, or ordinary cancellation-bridge replacement. Record selection,
+required journaling, G1/G2 acknowledgement, per-item results, actual request leases,
+long-lived replay and persisted physical uncertainty are unchanged.
+
+Per Alex's code-first instruction, this continuation did **not** run tests,
+compiler/typecheck, syntax checks, native tooling, or CloudKit operations. Exact
+source preimage/postimage hashes and GitHub publication were checked to avoid
+replacing unrelated source. That is publication integrity, not behavior evidence.
+New callback/error-path regression execution remains a native gate; the earlier
+21-method revision suite does not by itself qualify these new callback changes.
+
+## Existing revision contract and authored tests
+
+The model preference APIs remain sufficient at the source level; they are not
+newly invented or patched by this continuation. See
+[ReadingAnalyticsRevisionContract.md](ReadingAnalyticsRevisionContract.md).
+API clarification: `501f62791c0fd18295c3d2af0cf94accc9c784db`.
+Real Realm test source: `e8b899e57cf5493eca82c4598e449c2bafb08c44`;
+blob `e14062aeaa9ce1edb164fde2503993765eab5b6e`.
+
+That earlier test refinement corrected the overly exact two-upload script,
+foreign-author fixture setup, reseed-versus-backupRestore distinction and missing
+incoming deletion admission. It added final-write races, divergent own echoes,
+second-journal rollback and target-commit/tracking-failure replay cases.
+
+The fixture uses real Realm/journal/adapter implementations and two actual
+synchronizeAdapter conflict loops. Only remote IO and existing boundary/identity
+failure hooks are controlled. It is not Common's model, inverse, or application
+composition. Scripted CKRecords have no actual server change tags. Backup tests
+exercise adapter admission, not physical file replacement or process loss.
+
+The same already-registered source file remains
+`Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift`. Exact 21 method IDs:
 
 ```text
 OwnedRecordRevisionTests/testLatePopulatedDownloadRequeuesNewerEmptyValueWithoutReauthoring
@@ -86,63 +90,60 @@ OwnedRecordRevisionTests/testIncomingHardDeletionCannotEraseAcknowledgedEmptyRev
 OwnedRecordRevisionTests/testBackupRestoreWithholdsCopiedRowsUntilActualServerImport
 ```
 
-Executed: DEBUG Swift frontend syntax parse and exact published-blob verification.
-NOT executed: Apple typecheck, native Realm methods, composed Reader tests, live
-CloudKit requests, filesystem/process-loss restore or signed multidevice scenarios.
-Existing account/cancellation/partial-result/callback suites were left unchanged,
-not claimed rerun. Their native execution remains part of W1's approved gate.
+Historical evidence for e8b899e5: DEBUG syntax parse and published-blob comparison.
+Apple typecheck, the 21 native methods, Common/application composition, filesystem
+restore and signed multidevice qualification have not run. Historical parse results
+must not be extended to the new production changes. Existing account/cancellation,
+partial-result and callback suites remain unchanged and are not claimed rerun.
 
-## Removal boundary rechecked against actual callers
+## Cutover removal: actual remaining code dependency
 
-Core PR #7 at `012d9fb4aa0a0717213c454076d0602550f5eb8a` still contains
-`ReaderOrderedV2BigSyncTransport` (blob `228a53ffb7c2c74c71927636ed3f7022189d0feb`).
-Its acquire path still calls beginPostBarrierOutboundQuiescence and
-establishPostBarrierDrain; it retains source-resume/adoption/completion composition.
-Removing the recovery panel's mutation UI is not removal of these runtime callers.
-W6/W8 have not supplied the required complete caller-removal SHAs.
+W6 Core #7 at `1fa7174e09ee22326d20500875ca40358c9aa532` still reports old
+startup/lifecycle/cutover families as reachable. W8 Core #6 at
+`a841f46153574a40557eded7191b1c440d0e42cd` likewise has not closed its old
+orchestration callers. Neither owner has supplied complete caller-removal SHAs.
+Removing mutation UI is not removal of ReaderOrderedV2BigSyncTransport callers.
+The required coordination request is posted in root #21.
 
 | BigSync surface | Remaining responsibility |
 | --- | --- |
-| AcceptedHeadQuiescence (120 lines), PausedOutboundRecovery (115 lines) | Host-only deletion candidates after accepted-head/paused-reservation callers and their exclusive tests close. Neither is deleted here. |
-| OutboundCompletion | Remove source-publication wrappers only with callers; distinguish generic external-owner recovery. |
-| OutboundQuiescence synchronizer extension | Mixed final-drain/source APIs and ordinary principal/admission/submission handling. Keep the latter. |
-| BigSyncOutboundQuiescence persistent coordinator | Preserve decoding, real outstanding submissions and generic admission; never reinterpret an old barrier as settled. |
-| OutboundReplayRecovery | Keep exact operation identity, shared callback collector, generation-matched reconciliation and unknown outcomes. |
-| CloudKitRecordStore / RecordMutations | Keep once-only result delivery, partial results, record identity checks, retries and acknowledgements. |
-| SyncedEntityProtocol / journal / identity / model hooks | Keep general local atomicity, owner/binding and version selection contracts. |
+| AcceptedHeadQuiescence / PausedOutboundRecovery | Delete host-only exports with actual caller removal and exclusively matching tests. Not deleted yet. |
+| OutboundCompletion | Retire source-publication wrappers with callers; preserve independently supported external-owner recovery. |
+| Synchronizer OutboundQuiescence extension | Mixed final-drain/source APIs and ordinary principal/admission/submission handling; do not blanket-delete. |
+| BigSyncOutboundQuiescence persistent coordinator | Preserve decoding and actual outstanding submissions; old barriers must not silently become settled. |
+| OutboundReplayRecovery | Preserve exact operation identity, single-delivery collector, generation-matched reconciliation and unknown outcomes. |
+| RecordStore / RecordMutations / journal / identity / model hooks | Preserve ordinary synchronization safety and owned-version selection. |
 
 Ordinary save/delete still reaches admitOutboundBatch and
-modifyRecordsHoldingOutboundLease. The 982-line low-level outbound file, 633-line
-mixed synchronizer extension, 439-line replay extension and host-only extensions
-remain present. This continuation removes zero runtime paths, and introduces no
-new barrier, publication requirement, phase machine, second journal or success stub.
+modifyRecordsHoldingOutboundLease. Host-only exports remain callable by the old
+Core runtime. This pass deletes no old authority family and does not claim full
+collapse. No empty-success aliases, disabled guards, checkpoint clearing or forced
+old-state downgrade are used to make caller dependencies disappear.
 
-## W8 raw bootstrap-save question
+## Bootstrap scope decision
 
-The inspected ordinary-save path has no public arbitrary-CKRecord admission entry.
-`admitOutboundBatch(for:)` and `modifyRecordsHoldingOutboundLease(...)` are internal,
-require the actual active run/principal, and are used with model-prepared journal
-generations and the ordinary response handler. Calling public
-`CloudKitRecordStore.modifyRecords` directly is raw IO, not that admission contract.
-An account precheck alone does not supply outstanding-submission bookkeeping.
+W1 issue comment 5641950120 explicitly excludes a cloud winner-election/CAS or
+publication service from this batch. W8 withdrew its create-only transport API
+request in comment 5641954172. Explicit selected-snapshot/local installation is
+sufficient for isolated development composition. Production multi-install baseline
+selection remains a release/product decision, not an unfinished new W2 API.
 
-W8's create-once baseline selection is not automatically implemented by the RA-1
-revision preferences. Journal-backed model replication may reuse the ordinary path,
-but its selection semantics and real initialization binding require W8/W1 agreement.
-Do not fabricate a public wrapper, transport grant or claim a direct CKDatabase save
-is covered. Fixture/local baseline work may proceed; production raw-bootstrap
-transport binding remains an explicit unresolved boundary. The project-wide 5k stop
-is not permission to add another API family in this continuation.
+The existing admitted mutation entry remains internal/run-and-generation-bound.
+Raw CloudKitRecordStore/CKDatabase saves do not inherit its admission/settlement
+contract. No raw-baseline write wrapper or second synchronization path was added.
 
-## Accounting and next gates
+## Completion and release gates
 
-This continuation: **0 new/reimplemented production lines, 0 production deletions,
-0 source moves, +314/-6 test lines** (870 total test lines), two existing docs updated.
-No unrelated production test, manifest, workflow, identity format or callback changed.
-The earlier merged batch had 562 test lines and 276 documentation lines.
+Independent production fixes above are published. Export removal remains blocked
+on W6/W8's actual caller closure; W2 does not edit their repositories to fake closure.
+W1 alone approves integration and the exact composed tuple. Native qualification
+and production baseline/live-data permission remain separate gates.
 
-W1 must execute the 21 methods on the approved native runner and compose actual
-Common conformance. W6/W8 must supply caller-closure evidence before export removal.
-Until those gates close, this is a test/contract refinement, not completed transport
-collapse or qualification. No release/default merge, forced ref update, live baseline
-selection/migration, account/zone deletion, journal clearing or Mac worktree change.
+Accounting: production +103/-80; prior PR #11 test refinement +314/-6 unchanged;
+documentation separate; zero source moves and zero new production files. Existing
+21-method file is unchanged in this coding pass. No tests were deleted to hide a
+regression. This remains a draft, not a fully completed or qualified RA-1 app.
+
+No release/default merge, forced ref update, live migration, user baseline choice,
+account/zone deletion, journal clearing, source activation, native runner or
+protected Mac worktree operation was performed.

--- a/Documentation/ReadingAnalyticsWorker2.md
+++ b/Documentation/ReadingAnalyticsWorker2.md
@@ -1,45 +1,66 @@
-# RA-1 Worker 2 — published tests and remaining collapse boundary
+# RA-1 Worker 2 — revision review and remaining collapse boundary
 
-## Status
+## Status and revisions
 
-First deliverable is published; native qualification and cutover removal are NOT
-complete. No production source has been changed merely to add a new revision API.
-The existing adapter preferences already express the required decision; the new
-native suite must qualify their execution before this is called proven.
+PR #10 was merged normally by W1 at `5923cdccc39d90952865d27041ee7ac1168a1ac8`.
+This continuation does not modify that completed milestone branch. The existing
+production preferences remain unchanged; native qualification and cutover removal
+are NOT complete. Do not label authored tests as executed behavior.
 
-- Preserved input/base: `2a28f8cfa48fa16c471fa4d54c2689f21567905f`.
-- Work branch: `codex/reading-analytics-w2-sync-20260911`.
+- Production input: `2a28f8cfa48fa16c471fa4d54c2689f21567905f`.
+- Continuation base: `5923cdccc39d90952865d27041ee7ac1168a1ac8`.
+- Work branch: `codex/reading-analytics-w2-review-20260911`.
 - Target: `codex/reading-analytics-integration-20260911`.
-- Draft PR: https://github.com/lake-of-fire/BigSyncKit/pull/10 .
 - Coordinator: https://github.com/aehlke/manabi-reader/issues/21 .
-- Actual API note: `99c404cf07a19caf76b6b66fd916c40f1e08e674`,
+- Revised test commit: `e8b899e57cf5493eca82c4598e449c2bafb08c44`.
+- Revised test blob: `e14062aeaa9ce1edb164fde2503993765eab5b6e`.
+- Test SHA-256: `7472ad3235f64f8b862ab8675258d5b2fe76155d2d7bcb9b59083750fa3de8c3`.
+- API clarification commit: `501f62791c0fd18295c3d2af0cf94accc9c784db`,
   [ReadingAnalyticsRevisionContract.md](ReadingAnalyticsRevisionContract.md).
-- Native test source: `eefb5d24edc719b9ed009de49b801f44be721064`,
-  `Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift`.
-- Verified test blob: `453bfbde493f34d01de977fab97b6c464c6de241`.
-- Test SHA-256: `0b4e588d76e5eefd21bc15e5f77dd6e773561bba8e36ce3e590677884c3aec57`.
 
-## Implemented test surface
+## Findings and refinements
 
-The fixture is an actual Realm Object using the existing integer codec and model
-validation/preference protocols. Target and tracking Realms, mutation registration,
-throwing journal generation, import, serialization, own-echo validation and
-acknowledgement are real BigSync code. The two conflict-loop methods call the real
-`CloudKitSynchronizer.synchronizeAdapter`, including outbound admission and normal
-`serverRecordChanged -> forceSave import -> reprepare -> acknowledge` handling.
-Only remote IO is scripted; unexpected remote operations throw. The direct-upload
-run uses the same real account-validation/test-run setup as existing native tests,
-not a replacement admission coordinator or fabricated terminal receipt.
+1. The original conflict script required exactly two uploads. Source permits a
+   target G2 journal to outrun tracking G1: a retry can serialize the selected
+   current payload while acknowledging only G1, then drain the surviving G2.
+   The script now permits one conflict and at most two successful saves. Every
+   retry must contain the selected complete value and the final journal must drain.
+   A separate test explicitly freezes forwarding and asserts G1/G2 behavior without
+   fixture forwarding between preparation and acknowledgement. This is a corrected
+   harness assumption, not a native-reproduced production failure.
+2. The original conflict fixture authored owner-a under a random synchronizer
+   installation. The test author now checks owner equality. Conflict setup uses
+   actual inbound replication plus lower-version repair to queue a foreign value
+   unchanged. It does not relabel ownership or invent an authored revision.
+3. Local-dataset reseeding is not backup restoration. The real Realm test model now
+   implements the existing restore interface and local-only recovery flag, matching
+   W3's admission policy. Actual backupRestore preparation/bootstrap/reconciliation
+   is tested with absent, older, equal and newer server records. Validation-only own
+   echoes must not clear copied-state admission; normal import may re-admit it.
+4. Retained tombstone upserts do not themselves reject incoming hard deletions.
+   The fixture now implements the existing deletion validator, and a test checks
+   acknowledged empty/live and empty/tombstone state survives actual deletion input
+   and still repairs a subsequently received older positive version.
+5. New tests cover final-write selection races, equal-version divergence hidden by
+   a new pending journal, failure on the second required winner journal in one
+   target transaction, and failure between target and tracking Realm commits.
+   The former rolls back both target objects; the latter preserves the committed
+   winner and its journal for replay. No compensating downgrade is introduced.
 
-This model is not the Common model. W3 owns real application conformance and W1
-owns qualification of the composed tuple. The clock test proves no Common inverse:
-it checks transport of an explicitly supplied complete higher-version payload.
-Reseed uses isolated in-memory data and a controlled empty destination; it does not
-select a real user's baseline or qualify stale-copy admission.
+The model is not Common. The suite uses real Realm objects, target/tracking Realms,
+registration, journals, adapter application, serialization and acknowledgements.
+Only remote IO and existing scheduling/identity-failure hooks are controlled. The
+clock case transports an explicitly supplied complete payload; it does not test
+Common's Undo delta. Backup cases do not replace real Realm files or exercise the
+manual restore handoff. Scripted CKRecords have no real server change tags, so these
+are not CloudKit CAS or signed multidevice tests.
 
-W1 must register the new file in its explicit Tuist native test membership. SwiftPM
-already discovers files in the existing BigSyncKitTests directory. Exact class and
-method identifiers (12 methods, with bounded forceSave/tombstone variants):
+## Native test membership
+
+The same file remains `Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift`; W1's
+root registration for #10 covers it when this revision is selected. No new manifest
+entry is needed, but native discovery and execution remain required. There are now
+21 methods, not 12:
 
 ```text
 OwnedRecordRevisionTests/testLatePopulatedDownloadRequeuesNewerEmptyValueWithoutReauthoring
@@ -54,69 +75,74 @@ OwnedRecordRevisionTests/testRequiredJournalIdentityFailureRollsBackDomainAndRev
 OwnedRecordRevisionTests/testReseedKeepsOriginalOwnerAndRevisionUnderNewJournalIdentity
 OwnedRecordRevisionTests/testRealUploadLoopRetriesLowerServerConflictWithNewerLocalEmptyState
 OwnedRecordRevisionTests/testRealUploadLoopReplacesStalePendingMarkWithNewerServerEmptyState
+OwnedRecordRevisionTests/testNewerLocalRevisionAtFinalWriteOverridesSelectionSnapshot
+OwnedRecordRevisionTests/testHigherRemoteRevisionStillWinsAfterLocalJournalChangesDuringSelection
+OwnedRecordRevisionTests/testEqualRevisionDivergenceAtFinalWriteCannotBeHiddenByNewPendingWork
+OwnedRecordRevisionTests/testSecondIncomingWinnerJournalFailureRollsBackBothTargets
+OwnedRecordRevisionTests/testTrackingFailureAfterTargetCommitPreservesWinnerForReplayAndOldAck
+OwnedRecordRevisionTests/testPayloadAheadOfForwardedGenerationStillDrainsNewerJournal
+OwnedRecordRevisionTests/testDivergentOwnEchoIsQuarantinedWithoutApplyingOrAcknowledgingIt
+OwnedRecordRevisionTests/testIncomingHardDeletionCannotEraseAcknowledgedEmptyRevision
+OwnedRecordRevisionTests/testBackupRestoreWithholdsCopiedRowsUntilActualServerImport
 ```
 
-Executed: Swift frontend syntax parse with DEBUG defined, local file hashing and
-GitHub blob readback. NOT executed: Apple typecheck, native Realm tests, composed
-Reader tests, actual CloudKit requests or signed multidevice scenarios. No green
-historical suite is relabeled as evidence for this test commit.
+Executed: DEBUG Swift frontend syntax parse and exact published-blob verification.
+NOT executed: Apple typecheck, native Realm methods, composed Reader tests, live
+CloudKit requests, filesystem/process-loss restore or signed multidevice scenarios.
+Existing account/cancellation/partial-result/callback suites were left unchanged,
+not claimed rerun. Their native execution remains part of W1's approved gate.
 
-## Removal inventory and exact dependency boundary
+## Removal boundary rechecked against actual callers
 
-W6 Core PR #7 currently describes old orchestration as not yet removed. W8 Core
-PR #6 retains its real backup/restore handoff while implementing explicit import.
-Neither has supplied the required dependency-closed exported-API removal SHA.
-W2 has requested that confirmation in the umbrella issue. Do not delete exported
-APIs before their callers disappear, and do not leave successful no-op aliases.
+Core PR #7 at `012d9fb4aa0a0717213c454076d0602550f5eb8a` still contains
+`ReaderOrderedV2BigSyncTransport` (blob `228a53ffb7c2c74c71927636ed3f7022189d0feb`).
+Its acquire path still calls beginPostBarrierOutboundQuiescence and
+establishPostBarrierDrain; it retains source-resume/adoption/completion composition.
+Removing the recovery panel's mutation UI is not removal of these runtime callers.
+W6/W8 have not supplied the required complete caller-removal SHAs.
 
-| Current BigSync surface | Disposition for the collapse batch |
+| BigSync surface | Remaining responsibility |
 | --- | --- |
-| `CloudKitSynchronizer+AcceptedHeadQuiescence.swift` (120 lines) | Entire extension is accepted-head host orchestration; candidate for deletion with W6 accepted-head callers and exclusively matching tests/probes. |
-| `CloudKitSynchronizer+PausedOutboundRecovery.swift` (115 lines) | Sealed-domain reservation ownership handoff; candidate with W6/W8 paused-adoption callers. Not the ordinary replay implementation. |
-| `CloudKitSynchronizer+OutboundCompletion.swift` | Source-publication completion/token wrappers are candidates. Distinguish the generic external-owner recovery overload before deleting a whole file. |
-| `CloudKitSynchronizer+OutboundQuiescence.swift` | Mixed. Remove final-drain/reservation/source-publication entry points only with their clients. Retain ordinary principal, admission, submitted-request identity and local-settlement handling. |
-| `CloudKitSynchronizer.swift`, `CloudKitSynchronizer+Sync.swift`, `BigSyncBackgroundActor.swift` | Remove cutover configuration/tokens/run branches and forwarding methods as one closed batch. Preserve ordinary run/account/cancellation checks and independently used terminal/change-feed contracts. |
-| `BigSyncOutboundQuiescence.swift` | Mixed persistent format, physical admission, submission markers and old barrier operations. Never delete or reinterpret existing barrier/submission state as settled. Preserve diagnostic decoding and ordinary submission safety while removing domain-only operations. |
-| `CloudKitSynchronizer+OutboundReplayRecovery.swift` | Retain actual operation-identity validation, callback replay, generation-matched handling and unknown-result preservation. A failed operation lookup does not prove mutation rejection. |
-| `CloudKitRecordStore.swift`, `CloudKitSynchronizer+RecordMutations.swift` | Retain once-only callback collector, partial-result preservation, response identity checks and normal retry/acknowledgement flow. |
-| `SyncedEntityProtocol.swift`, `BigSyncPendingMutation.swift`, semantic hooks, identity/binding/restore files | Retain strict journals, generation safety, model winner semantics and owner/binding boundaries. No Reader Undo protocol belongs here. |
+| AcceptedHeadQuiescence (120 lines), PausedOutboundRecovery (115 lines) | Host-only deletion candidates after accepted-head/paused-reservation callers and their exclusive tests close. Neither is deleted here. |
+| OutboundCompletion | Remove source-publication wrappers only with callers; distinguish generic external-owner recovery. |
+| OutboundQuiescence synchronizer extension | Mixed final-drain/source APIs and ordinary principal/admission/submission handling. Keep the latter. |
+| BigSyncOutboundQuiescence persistent coordinator | Preserve decoding, real outstanding submissions and generic admission; never reinterpret an old barrier as settled. |
+| OutboundReplayRecovery | Keep exact operation identity, shared callback collector, generation-matched reconciliation and unknown outcomes. |
+| CloudKitRecordStore / RecordMutations | Keep once-only result delivery, partial results, record identity checks, retries and acknowledgements. |
+| SyncedEntityProtocol / journal / identity / model hooks | Keep general local atomicity, owner/binding and version selection contracts. |
 
-This is a dependency checklist, not a new lifecycle design. It does not authorize
-clearing a physical checkpoint, starting source mode, or silently reopening an old
-paused installation. A real-data decision about an existing barrier remains a
-named W1/W8 release boundary; isolated code/tests do not need that permission.
+Ordinary save/delete still reaches admitOutboundBatch and
+modifyRecordsHoldingOutboundLease. The 982-line low-level outbound file, 633-line
+mixed synchronizer extension, 439-line replay extension and host-only extensions
+remain present. This continuation removes zero runtime paths, and introduces no
+new barrier, publication requirement, phase machine, second journal or success stub.
 
-## Runtime reachability retained at this commit
+## W8 raw bootstrap-save question
 
-Ordinary upload/delete still invokes `admitOutboundBatch`, then
-`modifyRecordsHoldingOutboundLease`. The latter persists original record IDs,
-prepared generations and optional long-lived operation identity before submission.
-A known server result is not enough: marker retirement follows generation-matched
-local handling. Missing results, lost proxies, cancellation and account replacement
-must not be turned into successful settlement during collapse.
+The inspected ordinary-save path has no public arbitrary-CKRecord admission entry.
+`admitOutboundBatch(for:)` and `modifyRecordsHoldingOutboundLease(...)` are internal,
+require the actual active run/principal, and are used with model-prepared journal
+generations and the ordinary response handler. Calling public
+`CloudKitRecordStore.modifyRecords` directly is raw IO, not that admission contract.
+An account precheck alone does not supply outstanding-submission bookkeeping.
 
-The 982-line low-level outbound file, 633-line synchronizer quiescence extension,
-439-line replay extension and host-only extensions are still present, not counted
-as removed. Ordinary work reaches portions of the first three; the host-only paths
-remain callable by existing Core. RA-1 itself acquires no new barrier or publication
-proof. Removing a feature consumer is not proof that all this general code is dead.
+W8's create-once baseline selection is not automatically implemented by the RA-1
+revision preferences. Journal-backed model replication may reuse the ordinary path,
+but its selection semantics and real initialization binding require W8/W1 agreement.
+Do not fabricate a public wrapper, transport grant or claim a direct CKDatabase save
+is covered. Fixture/local baseline work may proceed; production raw-bootstrap
+transport binding remains an explicit unresolved boundary. The project-wide 5k stop
+is not permission to add another API family in this continuation.
 
 ## Accounting and next gates
 
-At test commit `eefb5d24`: 562 test lines, 154 API-document lines, 0 new/reimplemented
-production lines, 0 production deletions, 0 identical moves. This status note is
-additional documentation only. No unrelated production tests, workflows, manifests,
-identity formats or callback behavior were altered.
+This continuation: **0 new/reimplemented production lines, 0 production deletions,
+0 source moves, +314/-6 test lines** (870 total test lines), two existing docs updated.
+No unrelated production test, manifest, workflow, identity format or callback changed.
+The earlier merged batch had 562 test lines and 276 documentation lines.
 
-1. W1-approved native runner executes the 12 methods and retained account,
-   cancellation, partial-result, callback lifetime and generation suites. Fix any
-   demonstrated adapter gap, not the public API simply because a new model exists.
-2. W6/W8 publish removal SHAs for accepted-head, final aggregate drain/seal, paused
-   reservation/source publication and completion clients. W2 performs the closed
-   removal batch, preserving ordinary physical uncertainty. This gate is currently
-   outstanding; the assignment must not be labeled fully collapsed.
-3. W1 composes the actual Common conformance and owning Mark/Undo transactions with
-   this transport, registers tests and records native/signed qualification separately.
-
-No release/default merge, force push, live migration, account/zone deletion, journal
-clearing, source activation or Mac worktree change was performed.
+W1 must execute the 21 methods on the approved native runner and compose actual
+Common conformance. W6/W8 must supply caller-closure evidence before export removal.
+Until those gates close, this is a test/contract refinement, not completed transport
+collapse or qualification. No release/default merge, forced ref update, live baseline
+selection/migration, account/zone deletion, journal clearing or Mac worktree change.

--- a/Documentation/ReadingAnalyticsWorker2.md
+++ b/Documentation/ReadingAnalyticsWorker2.md
@@ -1,70 +1,105 @@
-# RA-1 Worker 2 — implementation and remaining integration boundary
+# RA-1 Worker 2 — actual implementation and remaining joins
 
-## Current production work
+## Published source
 
 PR #10 merged normally at `5923cdccc39d90952865d27041ee7ac1168a1ac8`.
 PR #11 continues on `codex/reading-analytics-w2-review-20260911`, targeting
 `codex/reading-analytics-integration-20260911`. Coordinator: root issue #21.
-The completed milestone branch and integration refs are not edited by W2.
-
-Code-first continuation after `9185ef1d3ba488a7b4febcace4249f79b6d791bb`:
+Only W1 merges integration batches; W2 does not modify completed milestone branches.
 
 | Commit | Implemented change |
 | --- | --- |
-| `7b5183b4e38320af92ce9817fc990936f0cc2ca0` | Record save/delete drain wrappers capture only the operation error and call their completion outside the operation catch. |
-| `3cbed7cd89f9413ab2d03fe765a95013fbad8950` | Upload composition and zone setup likewise separate downstream completion failures from operation failures; remove the nested upload catch that redelivered completion. |
-| `33e72a7500d0d7e13b7d827f68a0442c107b7a83` | Revalidate zone-fetch and zone-save failures before lifecycle writes; verify the returned zone identity before recording establishment. |
+| `7b5183b4e38320af92ce9817fc990936f0cc2ca0` | Save/delete drain completions are delivered outside operation catches, preventing downstream errors from causing a second delivery. |
+| `3cbed7cd89f9413ab2d03fe765a95013fbad8950` | Apply that separation through upload composition and zone lookup/creation; a consumer error is not zone-loss evidence. |
+| `33e72a7500d0d7e13b7d827f68a0442c107b7a83` | Revalidate original run/account on zone failures; require the fetched zone identity to match. |
+| `95e25ba7119733e0fb91e3ff17a5bd12846d2b55` | Reconciled manual restore queues unchanged known records under the new identity before releasing its existing durable intent. Completed intent cleanup is retryable without repeating replacement. |
 
-The source defect was `do { operation; completion(nil) } catch { completion(error) }`.
-A throwing consumer could receive a second result; zone setup could misinterpret a
-consumer's error as a failed zone operation. Each repaired wrapper now delivers
-one result. A completion error propagates to its caller rather than recursively
-invoking that completion or turning it into zone-loss evidence.
+The latest restore commit changes four paths: BackupDetection, BigSyncClientIdentity,
+SyncedEntityProtocol, and a 104-line Realm-specific handoff extension. It does not
+modify RealmSwiftAdapter, introduce another restore mode, or change revision ordering.
 
-Failed remote IO also suspends. Zone-fetch failure now revalidates the original
-attempt/account before inspecting the active context. Failed zone creation
-revalidates the captured run before classifying the original error. A mismatched
-fetched zone is not establishment evidence. These checks use existing APIs.
+## Concrete restore defect and correction
 
-Final production blobs:
-- RecordMutations: `cc4e76eeb76e3115d962d9a2a0b015c480df7fe2`.
-- Sync: `69dc38a2ed0f8613f77bfff3a68566383c1d3914`.
+W8's final-copy normalizer can correctly preserve independently current empty A@43
+against backup A@42, setting known43 awaiting=false and copied-only rows awaiting=true.
+But the existing `.backupRestore` preparation calls retainForRestoreRecovery again
+unless a record already has a journal generation in the current installation/binding.
+The flag alone is therefore not sufficient to preserve known43 through that later step.
 
-Exactly two existing production files changed: **+103/-80 (net +23)** relative to
-9185ef1d. There is no new API, model, framework, phase, ledger, source move,
-manifest change, or ordinary cancellation-bridge replacement. Record selection,
-required journaling, G1/G2 acknowledgement, per-item results, actual request leases,
-long-lived replay and persisted physical uncertainty are unchanged.
+The correction uses that existing current-identity journal exception. The new API is:
 
-Per Alex's code-first instruction, this continuation did **not** run tests,
-compiler/typecheck, syntax checks, native tooling, or CloudKit operations. Exact
-source preimage/postimage hashes and GitHub publication were checked to avoid
-replacing unrelated source. That is publication integrity, not behavior evidence.
-New callback/error-path regression execution remains a native gate; the earlier
-21-method revision suite does not by itself qualify these new callback changes.
+```swift
+BigSyncClientIdentity.withReconciledManualBackupRestore(
+    transactionIdentifier: UUID,
+    configurations: [Realm.Configuration],
+    reconciledObjectTypes: [Object.Type],
+    _ replacement: () throws -> Void,
+    rollback: () throws -> Void = {}
+) throws -> BigSyncManualBackupRestoreReceipt
+```
 
-## Existing revision contract and authored tests
+The actual sequence is: existing exclusive identity lease and durable intent; caller
+installs/normalizes final files; publish the new sentinel and replica binding; validate
+and journal admitted rows as unchanged repairs; persist the existing completion receipt;
+remove the intent. Only then may ordinary startup resume.
 
-The model preference APIs remain sufficient at the source level; they are not
-newly invented or patched by this continuation. See
-[ReadingAnalyticsRevisionContract.md](ReadingAnalyticsRevisionContract.md).
-API clarification: `501f62791c0fd18295c3d2af0cf94accc9c784db`.
-Real Realm test source: `e8b899e57cf5493eca82c4598e449c2bafb08c44`;
-blob `e14062aeaa9ce1edb164fde2503993765eab5b6e`.
+The journal changes transport attribution, not record owner, stateRevision, payload or
+audit dates. The adapter's existing backupRestore preparation retains those generations
+and their admitted records. Lower server versions then use the normal model preference;
+backup-only records remain withheld. Automatic/raw restoration remains conservative.
 
-That earlier test refinement corrected the overly exact two-upload script,
-foreign-author fixture setup, reseed-versus-backupRestore distinction and missing
-incoming deletion admission. It added final-write races, divergent own echoes,
-second-journal rollback and target-commit/tracking-failure replay cases.
+Required repair work is recorded as an optional requirement in the existing manual
+intent/event/completion receipt. Six-line old receipts still decode unchanged. A new
+reconciled receipt has one required marker; unknown shapes reject. A raw caller cannot
+resume a reconciled transaction and silently skip repair. The existing event identifier
+and public receipt identity remain unchanged.
 
-The fixture uses real Realm/journal/adapter implementations and two actual
-synchronizeAdapter conflict loops. Only remote IO and existing boundary/identity
-failure hooks are controlled. It is not Common's model, inverse, or application
-composition. Scripted CKRecords have no actual server change tags. Backup tests
-exercise adapter admission, not physical file replacement or process loss.
+A repair failure after event publication keeps the same durable intent and returns
+handoffPending. Partial per-Realm journal work can retry; it cannot become permission
+to roll back installed files. A completed receipt with failed intent cleanup retries
+cleanup only, not replacement or repair. Restore-event acknowledgement cannot bypass
+an unfinished reconciled handoff. There is no new journal, floor registry, cloud
+publication, general phase machine, or unconditional restore-admission flag.
 
-The same already-registered source file remains
-`Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift`. Exact 21 method IDs:
+## Required application binding — not claimed finished
+
+W3 owns BigSyncCloudKitPolicy; W8 owns the real comparison/physical replacement.
+Both ends must be composed. At reviewed Common b4846243, policy still called the raw
+manual restore and old unconditional copy normalizer, and installed journaling only
+after the receipt. The new helper alone does not fix that unmodified application path.
+Exact instructions were posted to Common #7 comment5642314851 and Core #6 comment5642294934.
+
+Before invoking the reconciled overload, register the already-existing mutation policy
+with identity.makeMutationJournalIdentityProvider(). Registration itself does not publish
+identity. Do not call prepareInstallation/installMutationTracking from inside the locked
+finalizer; those paths correctly reject a pending intent and may reacquire the lease.
+The helper requires that registered live provider to match the new identity.
+
+Pass final installed configurations, not staged or original files. Pass only concrete
+model types actually normalized against preserved originals by W8. They must implement
+BigSyncRestoredObjectRecovering, outbound validation and ChangeMetadataRecordable.
+The last normalizer must preserve known=false versus copied=true; do not run the old
+blanket retainForRestoreRecovery over these rows after comparison. Sessions require W5's
+real recoverable conformance, not a cast that silently skips them. Missing schema,
+registration, identity or model validation throws, rather than granting completion.
+
+The caller's existing replacement journal must retain originals and the exact transaction
+on handoffPending. Its replacement closure is idempotent for already-installed files.
+Guard rebinding and process receipt clearing belong to W4/W8's real restore completion,
+not to BigSync's record transport. No actual user restore or history selection was run.
+
+## Revision APIs and existing test source
+
+The existing preferIncomingRecord/preferExistingObject hooks and strict journals are
+unchanged. See [ReadingAnalyticsRevisionContract.md](ReadingAnalyticsRevisionContract.md).
+Test implementation e8b899e57cf5493eca82c4598e449c2bafb08c44, blob
+e14062aeaa9ce1edb164fde2503993765eab5b6e, remains unchanged in the coding passes.
+It uses real Realm/journal/adapter implementations and two actual synchronizeAdapter
+conflict loops. Only remote IO and existing boundary/identity-failure hooks are controlled.
+The model is not Common, and scripted records have no actual server change tags.
+
+Already-registered file: Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift.
+Exact 21 native method IDs:
 
 ```text
 OwnedRecordRevisionTests/testLatePopulatedDownloadRequeuesNewerEmptyValueWithoutReauthoring
@@ -90,60 +125,54 @@ OwnedRecordRevisionTests/testIncomingHardDeletionCannotEraseAcknowledgedEmptyRev
 OwnedRecordRevisionTests/testBackupRestoreWithholdsCopiedRowsUntilActualServerImport
 ```
 
-Historical evidence for e8b899e5: DEBUG syntax parse and published-blob comparison.
-Apple typecheck, the 21 native methods, Common/application composition, filesystem
-restore and signed multidevice qualification have not run. Historical parse results
-must not be extended to the new production changes. Existing account/cancellation,
-partial-result and callback suites remain unchanged and are not claimed rerun.
+These tests cover adapter backup admission, not the newly added reconciled manual
+file-handoff helper. Qualification must compose W8's physical replacement with actual
+BigSync backupRestore and a later server42, plus interrupted repair/cleanup retries.
+No tests, compiler/typecheck, syntax checks, native tooling or CloudKit operations were
+run in the two production coding passes. Earlier parsing evidence is historical and
+must not be applied to these changes. Only preimage/postimage hashes, diffs and GitHub
+publication identities were inspected for safe source publication.
 
-## Cutover removal: actual remaining code dependency
+## Cutover removal: actual code dependency remains
 
-W6 Core #7 at `1fa7174e09ee22326d20500875ca40358c9aa532` still reports old
-startup/lifecycle/cutover families as reachable. W8 Core #6 at
-`a841f46153574a40557eded7191b1c440d0e42cd` likewise has not closed its old
-orchestration callers. Neither owner has supplied complete caller-removal SHAs.
-Removing mutation UI is not removal of ReaderOrderedV2BigSyncTransport callers.
-The required coordination request is posted in root #21.
+Current inspected W6 Core #7 still retains ReaderOrderedV2BigSyncTransport and old
+startup/cutover callers. W8 has begun retiring owned orchestration files, but complete
+caller-removal SHAs for BigSync's exported cutover family have not been supplied.
+Removing mutation UI does not close those calls. No export or old authority family
+is falsely reported as removed in this PR.
 
-| BigSync surface | Remaining responsibility |
+| Surface | Disposition |
 | --- | --- |
-| AcceptedHeadQuiescence / PausedOutboundRecovery | Delete host-only exports with actual caller removal and exclusively matching tests. Not deleted yet. |
-| OutboundCompletion | Retire source-publication wrappers with callers; preserve independently supported external-owner recovery. |
-| Synchronizer OutboundQuiescence extension | Mixed final-drain/source APIs and ordinary principal/admission/submission handling; do not blanket-delete. |
-| BigSyncOutboundQuiescence persistent coordinator | Preserve decoding and actual outstanding submissions; old barriers must not silently become settled. |
-| OutboundReplayRecovery | Preserve exact operation identity, single-delivery collector, generation-matched reconciliation and unknown outcomes. |
-| RecordStore / RecordMutations / journal / identity / model hooks | Preserve ordinary synchronization safety and owned-version selection. |
+| AcceptedHeadQuiescence / PausedOutboundRecovery | Exact 120/115-line source deletion patch prepared separately, not applied while callers remain. Exclusive probes/test and manifest references need closure in the same batch. |
+| OutboundCompletion | Remove source-publication wrappers with callers; distinguish supported external-owner recovery. |
+| Synchronizer OutboundQuiescence | Mixed final-drain/source exports and ordinary principal/admission/submission handling. No blanket deletion. |
+| Persistent outbound coordinator / replay | Retain current decoding, outstanding submissions, exact operation identity, generation-matched handling and unknown outcomes. Existing barriers are not automatically settled. |
+| RecordStore / RecordMutations / journals / identity / preferences | Retain ordinary synchronization safety. |
 
-Ordinary save/delete still reaches admitOutboundBatch and
-modifyRecordsHoldingOutboundLease. Host-only exports remain callable by the old
-Core runtime. This pass deletes no old authority family and does not claim full
-collapse. No empty-success aliases, disabled guards, checkpoint clearing or forced
-old-state downgrade are used to make caller dependencies disappear.
+Ordinary save/delete still reaches admitOutboundBatch and modifyRecordsHoldingOutboundLease.
+Their physical submission bookkeeping is not an Undo protocol. A missing proxy, empty
+journal, expired timeout, unavailable old provider or lost lock is not settlement.
+The pending two-file source patch is only a first removal slice, not a completed mixed
+runtime collapse or a dependency-closed test/manifest batch. W1/W6/W8 must authorize
+its application after actual calls disappear. No successful compatibility alias exists.
 
-## Bootstrap scope decision
+## Accounting and next boundaries
 
-W1 issue comment 5641950120 explicitly excludes a cloud winner-election/CAS or
-publication service from this batch. W8 withdrew its create-only transport API
-request in comment 5641954172. Explicit selected-snapshot/local installation is
-sufficient for isolated development composition. Production multi-install baseline
-selection remains a release/product decision, not an unfinished new W2 API.
+Restore coding delta vs d664de02: **+201/-20 production**, four files, including one
+104-line new helper; no test changes, no identical moves, no manifest/workflow changes.
+Cumulative PR #11 production delta: **+304/-100**, including the prior two-file callback
+fix. Prior test refinement remains +314/-6; documentation and unapplied patch preparation
+are separate. The 235 prepared source deletions are NOT counted as runtime reduction.
+SwiftPM's existing source discovery includes the helper; actual app composition remains
+W1-owned. No cap increase or scope expansion is implied by this supported restore fix.
 
-The existing admitted mutation entry remains internal/run-and-generation-bound.
-Raw CloudKitRecordStore/CKDatabase saves do not inherit its admission/settlement
-contract. No raw-baseline write wrapper or second synchronization path was added.
+W1 excluded cloud baseline election/CAS/publication in comment5641950120; W8 withdrew
+its create-only API request in5641954172. Explicit selected local input is sufficient
+for isolated composition; production multi-install baseline policy remains separate.
+No raw-bootstrap save API or another transport family was added.
 
-## Completion and release gates
-
-Independent production fixes above are published. Export removal remains blocked
-on W6/W8's actual caller closure; W2 does not edit their repositories to fake closure.
-W1 alone approves integration and the exact composed tuple. Native qualification
-and production baseline/live-data permission remain separate gates.
-
-Accounting: production +103/-80; prior PR #11 test refinement +314/-6 unchanged;
-documentation separate; zero source moves and zero new production files. Existing
-21-method file is unchanged in this coding pass. No tests were deleted to hide a
-regression. This remains a draft, not a fully completed or qualified RA-1 app.
-
-No release/default merge, forced ref update, live migration, user baseline choice,
-account/zone deletion, journal clearing, source activation, native runner or
-protected Mac worktree operation was performed.
+Remaining: W3/W8's actual reconciled restore caller binding; W6/W8's cutover caller
+closure and resulting export/probe removal; W1-approved native and composed qualification.
+Published code is not an integrated app or release authorization. No release/default
+merge, forced ref, live migration, account/zone/journal clearing, source activation,
+foreign-source edit or protected Mac worktree operation was performed.

--- a/Sources/BigSyncKit/QSSynchronizer/BackupDetection.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/BackupDetection.swift
@@ -714,10 +714,11 @@ enum BackupDetection {
             return nil
         }
         let lines = value.split(separator: "\n").map(String.init)
-        if lines.first == "BigSyncKit manual restore v1",
-           lines.count >= 3,
-           let identifier = UUID(uuidString: lines[2]) {
-            return identifier.uuidString.lowercased()
+        if lines.first == "BigSyncKit manual restore v1" {
+            // An event ID alone must not admit a truncated or unknown manual
+            // handoff contract as if it were an ordinary automatic restore.
+            return manualRestoreReceipt(data: data)?
+                .restoreEventIdentifier.uuidString.lowercased()
         }
         guard let firstLine = lines.first,
               let identifier = UUID(uuidString: firstLine) else { return nil }
@@ -762,6 +763,17 @@ enum BackupDetection {
                     fileManager: fileManager
                   ) == expectedEventIdentifier else {
                 throw Error.restoreEventAcknowledgementVerificationFailed
+            }
+            if let event = manualRestoreReceipt(data: eventData),
+               event.requiresReconciledJournal {
+                // Required preparation belongs to the event, not merely the
+                // optional intent file. Missing intent is not completion proof.
+                guard manualRestoreReceipt(at: completedManualRestoreReceiptURL(
+                    sentinelURL: sentinelURL)) == event,
+                      installationIdentifier(sentinelURL: sentinelURL,
+                        fileManager: fileManager) == event.newInstallationIdentifier else {
+                    throw Error.restoreEventAcknowledgementVerificationFailed
+                }
             }
             do {
                 // Retire the optional pre-replacement intent first. A crash
@@ -980,8 +992,12 @@ enum BackupDetection {
     }
 
     static func manualRestoreReceipt(at url: URL) -> ManualRestoreReceipt? {
-        guard let data = try? Data(contentsOf: url),
-              let value = String(data: data, encoding: .utf8) else { return nil }
+        guard let data = try? Data(contentsOf: url) else { return nil }
+        return manualRestoreReceipt(data: data)
+    }
+
+    private static func manualRestoreReceipt(data: Data) -> ManualRestoreReceipt? {
+        guard let value = String(data: data, encoding: .utf8) else { return nil }
         let lines = value.split(separator: "\n").map(String.init)
         guard lines.count == 6 || lines.count == 7,
               lines[0] == "BigSyncKit manual restore v1",

--- a/Sources/BigSyncKit/QSSynchronizer/BackupDetection.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/BackupDetection.swift
@@ -51,6 +51,9 @@ enum BackupDetection {
         let restoreEventIdentifier: UUID
         let oldInstallationIdentifier: String
         let newInstallationIdentifier: String
+        // Recorded in the existing intent/event/receipt, not a second ledger.
+        // A raw restore caller cannot finish a reconciled restore after a crash.
+        var requiresReconciledJournal = false
     }
 
     enum ManualRestorePreflight: Equatable, Sendable {
@@ -356,7 +359,8 @@ enum BackupDetection {
         transactionIdentifier: UUID,
         sharedSentinelBaseURL: URL? = nil,
         fileManager: FileManager = .default,
-        sentinelPublisher: ((URL, FileManager) throws -> Void)? = nil
+        sentinelPublisher: ((URL, FileManager) throws -> Void)? = nil,
+        beforeCompletingHandoff: ((ManualRestoreReceipt) throws -> Void)? = nil
     ) throws -> ManualRestoreReceipt {
         let sentinelURL = defaultSentinelURL(
             namespace: namespace,
@@ -374,12 +378,20 @@ enum BackupDetection {
                 sentinelURL: sentinelURL,
                 fileManager: fileManager
             ) {
+                guard receipt.requiresReconciledJournal == (beforeCompletingHandoff != nil) else {
+                    throw Error.manualRestoreTransactionMismatch
+                }
+                // The completion receipt also covers journal preparation. A
+                // crash during intent cleanup must retry cleanup, not the work.
+                try removeManualRestoreIntentLocked(receipt, sentinelURL: sentinelURL,
+                    fileManager: fileManager)
                 return receipt
             }
             let receipt = try prepareManualRestoreIntentLocked(
                 transactionIdentifier: transactionIdentifier,
                 sentinelURL: sentinelURL,
-                fileManager: fileManager
+                fileManager: fileManager,
+                requiresReconciledJournal: beforeCompletingHandoff != nil
             )
             let eventURL = restoreEventURL(sentinelURL: sentinelURL)
             if !fileManager.fileExists(atPath: eventURL.path) {
@@ -418,6 +430,10 @@ enum BackupDetection {
             ) == receipt.newInstallationIdentifier else {
                 throw Error.manualRestoreStateAmbiguous
             }
+            // The durable intent keeps other writers fenced even if this
+            // fails after identity publication. Never mark the handoff complete
+            // or remove that intent until required unchanged repairs are queued.
+            try beforeCompletingHandoff?(receipt)
             try persistManualRestoreReceiptExcludingBackup(
                 receipt,
                 at: completedManualRestoreReceiptURL(
@@ -439,7 +455,8 @@ enum BackupDetection {
         namespace: String,
         transactionIdentifier: UUID,
         sharedSentinelBaseURL: URL? = nil,
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        requiresReconciledJournal: Bool = false
     ) throws -> ManualRestoreReceipt {
         let sentinelURL = defaultSentinelURL(
             namespace: namespace,
@@ -455,7 +472,8 @@ enum BackupDetection {
             try prepareManualRestoreIntentLocked(
                 transactionIdentifier: transactionIdentifier,
                 sentinelURL: sentinelURL,
-                fileManager: fileManager
+                fileManager: fileManager,
+                requiresReconciledJournal: requiresReconciledJournal
             )
         }
     }
@@ -583,7 +601,8 @@ enum BackupDetection {
     private static func prepareManualRestoreIntentLocked(
         transactionIdentifier: UUID,
         sentinelURL: URL,
-        fileManager: FileManager
+        fileManager: FileManager,
+        requiresReconciledJournal: Bool = false
     ) throws -> ManualRestoreReceipt {
         let receipt: ManualRestoreReceipt
         switch try manualRestorePreflightLocked(
@@ -593,6 +612,9 @@ enum BackupDetection {
         ) {
         case .resumeIntent(let existing), .resumeEvent(let existing),
              .completed(let existing):
+            guard existing.requiresReconciledJournal == requiresReconciledJournal else {
+                throw Error.manualRestoreTransactionMismatch
+            }
             receipt = existing
         case .newTransaction:
             guard let oldInstallationIdentifier = installationIdentifier(
@@ -605,7 +627,8 @@ enum BackupDetection {
                 transactionIdentifier: transactionIdentifier,
                 restoreEventIdentifier: UUID(),
                 oldInstallationIdentifier: oldInstallationIdentifier,
-                newInstallationIdentifier: UUID().uuidString.lowercased()
+                newInstallationIdentifier: UUID().uuidString.lowercased(),
+                requiresReconciledJournal: requiresReconciledJournal
             )
             try persistManualRestoreIntent(
                 receipt,
@@ -751,6 +774,11 @@ enum BackupDetection {
                     at: manualRestoreIntentURL(sentinelURL: sentinelURL)
                 ), intent.restoreEventIdentifier.uuidString.lowercased()
                     == expectedEventIdentifier {
+                    if intent.requiresReconciledJournal,
+                       manualRestoreReceipt(at: completedManualRestoreReceiptURL(
+                        sentinelURL: sentinelURL)) != intent {
+                        throw Error.restoreEventAcknowledgementVerificationFailed
+                    }
                     try removeManualRestoreIntentLocked(
                         intent,
                         sentinelURL: sentinelURL,
@@ -955,18 +983,20 @@ enum BackupDetection {
         guard let data = try? Data(contentsOf: url),
               let value = String(data: data, encoding: .utf8) else { return nil }
         let lines = value.split(separator: "\n").map(String.init)
-        guard lines.count == 6,
+        guard lines.count == 6 || lines.count == 7,
               lines[0] == "BigSyncKit manual restore v1",
               let transactionIdentifier = UUID(uuidString: lines[1]),
               let restoreEventIdentifier = UUID(uuidString: lines[2]),
               let oldInstallationIdentifier = UUID(uuidString: lines[3]),
               let newInstallationIdentifier = UUID(uuidString: lines[4]),
-              lines[5] == "end" else { return nil }
+              lines.last == "end",
+              lines.count == 6 || lines[5] == "reconciled-journal" else { return nil }
         return ManualRestoreReceipt(
             transactionIdentifier: transactionIdentifier,
             restoreEventIdentifier: restoreEventIdentifier,
             oldInstallationIdentifier: oldInstallationIdentifier.uuidString.lowercased(),
-            newInstallationIdentifier: newInstallationIdentifier.uuidString.lowercased()
+            newInstallationIdentifier: newInstallationIdentifier.uuidString.lowercased(),
+            requiresReconciledJournal: lines.count == 7
         )
     }
 
@@ -1052,8 +1082,9 @@ enum BackupDetection {
     private static func manualRestoreData(
         _ receipt: ManualRestoreReceipt
     ) -> Data {
-        Data(
-            "BigSyncKit manual restore v1\n\(receipt.transactionIdentifier.uuidString.lowercased())\n\(receipt.restoreEventIdentifier.uuidString.lowercased())\n\(receipt.oldInstallationIdentifier)\n\(receipt.newInstallationIdentifier)\nend\n".utf8
+        let preparation = receipt.requiresReconciledJournal ? "reconciled-journal\n" : ""
+        return Data(
+            "BigSyncKit manual restore v1\n\(receipt.transactionIdentifier.uuidString.lowercased())\n\(receipt.restoreEventIdentifier.uuidString.lowercased())\n\(receipt.oldInstallationIdentifier)\n\(receipt.newInstallationIdentifier)\n\(preparation)end\n".utf8
         )
     }
 

--- a/Sources/BigSyncKit/QSSynchronizer/BigSyncClientIdentity.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/BigSyncClientIdentity.swift
@@ -360,6 +360,18 @@ public struct BigSyncClientIdentity: Sendable {
     @discardableResult
     public func prepareReplicaBindingGenerationIdentifier() throws -> String {
         let installationIdentifier = try prepareInstallation()
+        return try prepareReplicaBindingGenerationIdentifier(forPublishedInstallation: installationIdentifier)
+    }
+
+    /// The reconciled restore calls this while it still owns the exclusive
+    /// lease and durable intent. Do not reacquire a shared lease or recursively
+    /// run backup detection from inside that locked handoff.
+    internal func prepareReplicaBindingGenerationIdentifier(
+        forPublishedInstallation installationIdentifier: String
+    ) throws -> String {
+        guard publishedInstallationIdentifier() == installationIdentifier else {
+            throw BigSyncManualBackupRestoreError.stateAmbiguous
+        }
         let store = FileKeyValueStore(
             fileURL: synchronizationStateFileURL
         )
@@ -476,7 +488,8 @@ public struct BigSyncClientIdentity: Sendable {
         transactionIdentifier: UUID,
         _ replacement: () throws -> Void,
         rollback: () throws -> Void = {},
-        sentinelPublisher: ((URL, FileManager) throws -> Void)?
+        sentinelPublisher: ((URL, FileManager) throws -> Void)?,
+        beforeCompletingHandoff: ((BackupDetection.ManualRestoreReceipt) throws -> Void)? = nil
     ) throws -> BigSyncManualBackupRestoreReceipt {
         try BigSyncClientIdentityLeaseRegistry.withExclusive(at: leaseURL) {
             let preflight: BackupDetection.ManualRestorePreflight
@@ -494,9 +507,31 @@ public struct BigSyncClientIdentity: Sendable {
 
             switch preflight {
             case .completed(let existingReceipt):
-                return makeManualRestoreReceipt(existingReceipt)
+                guard existingReceipt.requiresReconciledJournal == (beforeCompletingHandoff != nil) else {
+                    throw BigSyncManualBackupRestoreError.transactionMismatch
+                }
+                // Completion may have reached disk before intent cleanup.
+                // Resume that exact cleanup, without replacing files or
+                // queueing the reconciled values again. Cleanup failure is
+                // still post-event: the caller must not roll back its files.
+                do {
+                    return try makeManualRestoreReceipt(BackupDetection.beginManualRestore(
+                        namespace: durableStateNamespace,
+                        transactionIdentifier: transactionIdentifier,
+                        sharedSentinelBaseURL: sharedStateBaseURL,
+                        sentinelPublisher: sentinelPublisher,
+                        beforeCompletingHandoff: beforeCompletingHandoff
+                    ))
+                } catch {
+                    throw BigSyncManualBackupRestoreError.handoffPending(
+                        makeManualRestoreReceipt(existingReceipt)
+                    )
+                }
 
             case .resumeEvent(let existingReceipt):
+                guard existingReceipt.requiresReconciledJournal == (beforeCompletingHandoff != nil) else {
+                    throw BigSyncManualBackupRestoreError.transactionMismatch
+                }
                 let publicReceipt = makeManualRestoreReceipt(existingReceipt)
                 // The caller's journal determines whether this closure is an
                 // idempotent verification/no-op or must finish installing the
@@ -515,7 +550,8 @@ public struct BigSyncClientIdentity: Sendable {
                             namespace: durableStateNamespace,
                             transactionIdentifier: transactionIdentifier,
                             sharedSentinelBaseURL: sharedStateBaseURL,
-                            sentinelPublisher: sentinelPublisher
+                            sentinelPublisher: sentinelPublisher,
+                            beforeCompletingHandoff: beforeCompletingHandoff
                         )
                     )
                 } catch {
@@ -537,7 +573,8 @@ public struct BigSyncClientIdentity: Sendable {
                     intentReceipt = try BackupDetection.prepareManualRestoreIntent(
                         namespace: durableStateNamespace,
                         transactionIdentifier: transactionIdentifier,
-                        sharedSentinelBaseURL: sharedStateBaseURL
+                        sharedSentinelBaseURL: sharedStateBaseURL,
+                        requiresReconciledJournal: beforeCompletingHandoff != nil
                     )
                 } catch BackupDetection.Error.manualRestoreTransactionMismatch {
                     throw BigSyncManualBackupRestoreError.transactionMismatch
@@ -562,7 +599,8 @@ public struct BigSyncClientIdentity: Sendable {
                             namespace: durableStateNamespace,
                             transactionIdentifier: transactionIdentifier,
                             sharedSentinelBaseURL: sharedStateBaseURL,
-                            sentinelPublisher: sentinelPublisher
+                            sentinelPublisher: sentinelPublisher,
+                            beforeCompletingHandoff: beforeCompletingHandoff
                         )
                     )
                 } catch let publicationError {
@@ -583,7 +621,12 @@ public struct BigSyncClientIdentity: Sendable {
                     }
                     switch stateAfterFailure {
                     case .completed(let receipt):
-                        return makeManualRestoreReceipt(receipt)
+                        // The receipt may precede a failed intent cleanup.
+                        // Let the exact retry finish that cleanup before the
+                        // host records a successful handoff and stops retrying.
+                        throw BigSyncManualBackupRestoreError.handoffPending(
+                            makeManualRestoreReceipt(receipt)
+                        )
                     case .resumeEvent(let receipt):
                         let publicReceipt = makeManualRestoreReceipt(receipt)
                         let currentIdentifier = publishedInstallationIdentifier()
@@ -646,7 +689,7 @@ public struct BigSyncClientIdentity: Sendable {
         ).newInstallationIdentifier
     }
 
-    private var leaseURL: URL {
+    internal var leaseURL: URL {
         BackupDetection.defaultSentinelURL(
             namespace: durableStateNamespace,
             sharedBaseURL: sharedStateBaseURL

--- a/Sources/BigSyncKit/QSSynchronizer/BigSyncClientIdentity.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/BigSyncClientIdentity.swift
@@ -88,11 +88,12 @@ enum BigSyncClientIdentityLeaseRegistry {
         lock.lock()
         defer { lock.unlock() }
         let lease = try lease(at: url)
-        guard lease.mode != .shared else { return }
-        guard bigSyncFlock(lease.descriptor, LOCK_SH) == 0 else {
-            throw BigSyncClientIdentityLeaseError.leaseUnavailable(Int32(errno))
+        // A replacement may query current identity, but must not prepare it
+        // recursively: that would downgrade LOCK_EX and can reenter the event
+        // file lock. Only the outer withExclusive scope releases its lease.
+        guard lease.mode == .shared else {
+            throw BigSyncClientIdentityLeaseError.restoreInProgress
         }
-        lease.mode = .shared
     }
 
     static func cachedInstallationIdentifier(at url: URL) -> String? {
@@ -127,10 +128,13 @@ enum BigSyncClientIdentityLeaseRegistry {
         lock.lock()
         defer { lock.unlock() }
         let lease = try lease(at: url)
-        if lease.mode == .shared {
-            guard bigSyncFlock(lease.descriptor, LOCK_UN) == 0 else {
-                throw BigSyncClientIdentityLeaseError.leaseUnavailable(Int32(errno))
-            }
+        // The recursive registry lock permits read-only identity checks, not
+        // nested restore mutations whose defer would release the outer lease.
+        guard lease.mode == .shared else {
+            throw BigSyncClientIdentityLeaseError.restoreInProgress
+        }
+        guard bigSyncFlock(lease.descriptor, LOCK_UN) == 0 else {
+            throw BigSyncClientIdentityLeaseError.leaseUnavailable(Int32(errno))
         }
         guard bigSyncFlock(lease.descriptor, LOCK_EX | LOCK_NB) == 0 else {
             let lockError = Int32(errno)
@@ -286,9 +290,11 @@ public struct BigSyncClientIdentity: Sendable {
                 // replacement with the old installation identity.
                 throw BigSyncManualBackupRestoreError.handoffPending(receipt)
             }
-            guard identifier == receipt.newInstallationIdentifier,
-                  pendingManualEvent != nil else {
+            guard identifier == receipt.newInstallationIdentifier else {
                 throw BigSyncManualBackupRestoreError.stateAmbiguous
+            }
+            guard manualRestoreHasRequiredCompletion(pendingManualRestore) else {
+                throw BigSyncManualBackupRestoreError.handoffPending(receipt)
             }
         } else if BackupDetection.restoreResetIsRequired(
             namespace: durableStateNamespace,
@@ -337,7 +343,7 @@ public struct BigSyncClientIdentity: Sendable {
             // proves the event's new installation, making such a write fail
             // closed instead of attributing it to the old installation.
             guard identifier == pendingManualRestore.newInstallationIdentifier,
-                  pendingManualEvent != nil
+                  manualRestoreHasRequiredCompletion(pendingManualRestore)
             else { return nil }
         } else if BackupDetection.restoreResetIsRequired(
             namespace: durableStateNamespace,
@@ -666,6 +672,20 @@ public struct BigSyncClientIdentity: Sendable {
             oldInstallationIdentifier: receipt.oldInstallationIdentifier,
             newInstallationIdentifier: receipt.newInstallationIdentifier
         )
+    }
+
+    /// A lost intent cannot promote an unfinished reconciled handoff. The
+    /// already-existing completion receipt covers its required repair journals.
+    private func manualRestoreHasRequiredCompletion(
+        _ receipt: BackupDetection.ManualRestoreReceipt
+    ) -> Bool {
+        guard receipt.requiresReconciledJournal else { return true }
+        let sentinelURL = BackupDetection.defaultSentinelURL(
+            namespace: durableStateNamespace, sharedBaseURL: sharedStateBaseURL
+        )
+        return BackupDetection.manualRestoreReceipt(
+            at: BackupDetection.completedManualRestoreReceiptURL(sentinelURL: sentinelURL)
+        ) == receipt
     }
 
     private func publishedInstallationIdentifier() -> String? {

--- a/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+RecordMutations.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+RecordMutations.swift
@@ -102,16 +102,19 @@ extension CloudKitSynchronizer {
         attemptID: UUID,
         completion: @Sendable @BigSyncBackgroundActor @escaping (Error?) async throws -> Void
     ) async throws {
+        let operationError: Error?
         do {
             try await drainRecordUploadsUsingAsyncStore(
                 adapter: adapter,
                 restrictedToEntityType: restrictedToEntityType,
                 attemptID: attemptID
             )
-            try await completion(nil)
+            operationError = nil
         } catch {
-            try await completion(error)
+            operationError = error
         }
+        // A downstream completion failure is not another transport result.
+        try await completion(operationError)
     }
 
     @BigSyncBackgroundActor
@@ -304,16 +307,19 @@ extension CloudKitSynchronizer {
         attemptID: UUID,
         completion: @Sendable @BigSyncBackgroundActor @escaping (Error?) async throws -> Void
     ) async throws {
+        let operationError: Error?
         do {
             try await drainRecordDeletionsUsingAsyncStore(
                 adapter: adapter,
                 restrictedToEntityType: restrictedToEntityType,
                 attemptID: attemptID
             )
-            try await completion(nil)
+            operationError = nil
         } catch {
-            try await completion(error)
+            operationError = error
         }
+        // A downstream completion failure is not another transport result.
+        try await completion(operationError)
     }
 
     @BigSyncBackgroundActor

--- a/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+Sync.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+Sync.swift
@@ -1599,15 +1599,19 @@ extension CloudKitSynchronizer {
     func uploadChanges(
         completion: @Sendable @BigSyncBackgroundActor @escaping (Error?) async throws -> ()
     ) async throws {
+        let operationError: Error?
         do {
             for adapter in modelAdapters {
                 try Task.checkCancellation()
                 try await synchronizeAdapter(adapter)
             }
-            try await completion(nil)
+            operationError = nil
         } catch {
-            try await completion(error)
+            operationError = error
         }
+        // Token publication/follow-up fetching belongs to the consumer. A
+        // failure there must not re-enter that consumer as a second result.
+        try await completion(operationError)
     }
     
     @BigSyncBackgroundActor
@@ -1646,28 +1650,24 @@ extension CloudKitSynchronizer {
                 try await completion(error)
                 return
             }
-            do {
-                try await uploadRecordsUsingAsyncStore(
-                    adapter: adapter,
-                    restrictedToEntityType: restrictedToEntityType,
-                    attemptID: attemptID,
-                    completion: { [weak self] (error) in
-                        guard let self else {
-                            try await completion(CancellationError())
-                            return
-                        }
-                        do {
-                            try checkSynchronizationAttempt(attemptID)
-                        } catch {
-                            try await completion(error)
-                            return
-                        }
-                        try await completion(error)
+            try await uploadRecordsUsingAsyncStore(
+                adapter: adapter,
+                restrictedToEntityType: restrictedToEntityType,
+                attemptID: attemptID,
+                completion: { [weak self] error in
+                    guard let self else {
+                        try await completion(CancellationError())
+                        return
                     }
-                )
-            } catch {
-                try await completion(error)
-            }
+                    do {
+                        try checkSynchronizationAttempt(attemptID)
+                    } catch {
+                        try await completion(error)
+                        return
+                    }
+                    try await completion(error)
+                }
+            )
         }
     }
     
@@ -1698,6 +1698,7 @@ extension CloudKitSynchronizer {
         attemptID: UUID,
         completion: @Sendable @BigSyncBackgroundActor @escaping (Error?) async throws -> ()
     ) async throws {
+        let lookupError: Error?
         do {
             // Validate immediately before and after each account-routed await.
             try await revalidateActiveRunContext(for: attemptID)
@@ -1709,70 +1710,73 @@ extension CloudKitSynchronizer {
                     accountScopeIdentifier: context.accountScopeIdentifier
                 )
             }
-            try await completion(nil)
+            lookupError = nil
         } catch {
-            do {
-                // Account replacement or cancellation wins over interpreting
-                // an obsolete zone lookup as evidence that a zone is missing.
-                try await revalidateActiveRunContext(for: attemptID)
-            } catch {
-                try await completion(error)
-                return
-            }
-
-            guard let context = activeRunContext else {
-                try await completion(error)
-                return
-            }
-            let classification = CloudKitLossClassifier.classify(
-                error: error,
-                defaultZoneID: zoneID
-            )
-            guard let disposition = classification.zoneDispositions[zoneID]
-            else {
-                try await completion(error)
-                return
-            }
-            if let lifecycleError = applyCloudKitLoss(
-                disposition,
-                zoneID: zoneID,
-                context: context,
-                allowsEncryptedBootstrapAbsence:
-                    isEncryptedDataResetRecoveryActive
-            ) {
-                try await completion(lifecycleError)
-                return
-            }
-
-            let newZone = CKRecordZone(zoneID: zoneID)
-            do {
-                try await revalidateActiveRunContext(for: attemptID)
-                let savedZone = try await zoneStore.save(recordZone: newZone)
-                try await revalidateActiveRunContext(for: attemptID)
-                guard savedZone.zoneID == zoneID else {
-                    throw CocoaError(.coderValueNotFound)
-                }
-                try markConfiguredZoneEstablished(
-                    zoneID,
-                    accountScopeIdentifier: context.accountScopeIdentifier
-                )
-                logger.info(
-                    "QSCloudKitSynchronizer >> Created custom record zone: \(newZone.description)"
-                )
-                try await completion(nil)
-            } catch {
-                if let lifecycleError = applyCloudKitLoss(
-                    error: error,
-                    defaultZoneID: zoneID,
-                    context: context,
-                    allowsEncryptedBootstrapAbsence: false
-                ) {
-                    try await completion(lifecycleError)
-                } else {
-                    try await completion(error)
-                }
-            }
+            lookupError = error
         }
+        guard let lookupError else {
+            try await completion(nil)
+            return
+        }
+
+        do {
+            // Account replacement or cancellation wins over interpreting
+            // an obsolete zone lookup as evidence that a zone is missing.
+            try await revalidateActiveRunContext(for: attemptID)
+        } catch {
+            try await completion(error)
+            return
+        }
+        guard let context = activeRunContext else {
+            try await completion(lookupError)
+            return
+        }
+        let classification = CloudKitLossClassifier.classify(
+            error: lookupError,
+            defaultZoneID: zoneID
+        )
+        guard let disposition = classification.zoneDispositions[zoneID] else {
+            try await completion(lookupError)
+            return
+        }
+        if let lifecycleError = applyCloudKitLoss(
+            disposition,
+            zoneID: zoneID,
+            context: context,
+            allowsEncryptedBootstrapAbsence: isEncryptedDataResetRecoveryActive
+        ) {
+            try await completion(lifecycleError)
+            return
+        }
+
+        let newZone = CKRecordZone(zoneID: zoneID)
+        let saveError: Error?
+        do {
+            try await revalidateActiveRunContext(for: attemptID)
+            let savedZone = try await zoneStore.save(recordZone: newZone)
+            try await revalidateActiveRunContext(for: attemptID)
+            guard savedZone.zoneID == zoneID else {
+                throw CocoaError(.coderValueNotFound)
+            }
+            try markConfiguredZoneEstablished(
+                zoneID,
+                accountScopeIdentifier: context.accountScopeIdentifier
+            )
+            logger.info(
+                "QSCloudKitSynchronizer >> Created custom record zone: \(newZone.description)"
+            )
+            saveError = nil
+        } catch {
+            saveError = applyCloudKitLoss(
+                error: error,
+                defaultZoneID: zoneID,
+                context: context,
+                allowsEncryptedBootstrapAbsence: false
+            ) ?? error
+        }
+        // Deliver outside both operation catches. A completion may itself
+        // perform a fallible upload; that must never become zone-loss evidence.
+        try await completion(saveError)
     }
 
     @BigSyncBackgroundActor

--- a/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+Sync.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+Sync.swift
@@ -1303,6 +1303,9 @@ extension CloudKitSynchronizer {
                         resultsLimit: 200
                     )
                 } catch {
+                    // Failed IO suspends just like successful IO. Reject an old
+                    // attempt/account before writing zone-loss recovery state.
+                    try await revalidateActiveRunContext(for: attemptID)
                     guard let context = activeRunContext else {
                         throw error
                     }
@@ -1702,8 +1705,11 @@ extension CloudKitSynchronizer {
         do {
             // Validate immediately before and after each account-routed await.
             try await revalidateActiveRunContext(for: attemptID)
-            _ = try await zoneStore.recordZone(withID: zoneID)
+            let zone = try await zoneStore.recordZone(withID: zoneID)
             try await revalidateActiveRunContext(for: attemptID)
+            guard zone.zoneID == zoneID else {
+                throw CocoaError(.coderValueNotFound)
+            }
             if let context = activeRunContext {
                 try markConfiguredZoneEstablished(
                     zoneID,
@@ -1767,12 +1773,19 @@ extension CloudKitSynchronizer {
             )
             saveError = nil
         } catch {
-            saveError = applyCloudKitLoss(
-                error: error,
-                defaultZoneID: zoneID,
-                context: context,
-                allowsEncryptedBootstrapAbsence: false
-            ) ?? error
+            let operationError = error
+            do {
+                // Never classify an old save's failure under a new account/run.
+                try await revalidateRunContext(context)
+                saveError = applyCloudKitLoss(
+                    error: operationError,
+                    defaultZoneID: zoneID,
+                    context: context,
+                    allowsEncryptedBootstrapAbsence: false
+                ) ?? operationError
+            } catch {
+                saveError = error
+            }
         }
         // Deliver outside both operation catches. A completion may itself
         // perform a fallible upload; that must never become zone-loss evidence.

--- a/Sources/BigSyncKit/RealmSwift/BigSyncReconciledManualRestore.swift
+++ b/Sources/BigSyncKit/RealmSwift/BigSyncReconciledManualRestore.swift
@@ -1,0 +1,104 @@
+import Foundation
+import RealmSwift
+
+public extension BigSyncClientIdentity {
+    /// Completes a caller-reconciled manual restore under the existing exclusive
+    /// identity lease. `replacement` must install the final Realm files and, for
+    /// every listed type, preserve only independently known current values with
+    /// isAwaitingRecoveryEvidence == false. Backup-only values must be withheld.
+    ///
+    /// This does not compare backups or select history. Only the caller possessing
+    /// the preserved originals can establish that distinction. Do not use this
+    /// overload for an automatic/raw backup, or before the final copy normalizer.
+    /// Listed types must implement the existing restore and outbound validators.
+    ///
+    /// After the new installation/binding is published, admitted values acquire
+    /// ordinary unchanged-repair journals before the durable restore intent is
+    /// released. The actual backupRestore adapter then preserves those generations
+    /// while withholding copied values and retiring copied journals as before.
+    /// Failure retains the exact handoff for retry with the same transaction ID.
+    @discardableResult
+    func withReconciledManualBackupRestore(
+        transactionIdentifier: UUID,
+        configurations: [Realm.Configuration],
+        reconciledObjectTypes: [Object.Type],
+        _ replacement: () throws -> Void,
+        rollback: () throws -> Void = {}
+    ) throws -> BigSyncManualBackupRestoreReceipt {
+        guard !configurations.isEmpty, !reconciledObjectTypes.isEmpty else {
+            throw BigSyncMutationJournalError.objectUnavailable
+        }
+        for type in reconciledObjectTypes {
+            guard type is BigSyncRestoredObjectRecovering.Type,
+                  type is BigSyncOutboundSemanticObjectValidating.Type,
+                  type is ChangeMetadataRecordable.Type else {
+                throw BigSyncMutationJournalError.unregisteredModel(type.className())
+            }
+        }
+        return try withManualBackupRestore(
+            transactionIdentifier: transactionIdentifier,
+            replacement,
+            rollback: rollback,
+            sentinelPublisher: nil,
+            beforeCompletingHandoff: { receipt in
+                let binding = try prepareReplicaBindingGenerationIdentifier(
+                    forPublishedInstallation: receipt.newInstallationIdentifier
+                )
+                let identity = BigSyncMutationJournalIdentity(
+                    installationIdentifier: receipt.newInstallationIdentifier,
+                    replicaBindingGenerationIdentifier: binding
+                )
+                // This synchronous closure still owns the exclusive process
+                // lease and durable intent. Permit only its nested journal
+                // provider reads; all other processes remain fenced. On failure
+                // the cache must not bypass the still-pending durable intent.
+                BigSyncClientIdentityLeaseRegistry.publishInstallationIdentifier(
+                    identity.installationIdentifier, at: leaseURL
+                )
+                defer {
+                    BigSyncClientIdentityLeaseRegistry.invalidateInstallationIdentifier(at: leaseURL)
+                }
+                var opened = Set<String>()
+                var foundTypes = Set<String>()
+                let timestamp = Date()
+                for configuration in configurations {
+                    let configurationID = BigSyncMutationTrackingRegistry.identity(for: configuration)
+                    guard opened.insert(configurationID).inserted else { continue }
+                    let realm = try Realm(configuration: configuration)
+                    let types = reconciledObjectTypes.filter { type in
+                        realm.schema.objectSchema.contains { $0.className == type.className() }
+                    }
+                    guard !types.isEmpty else { continue }
+                    var processedTypes = Set<String>()
+                    try realm.write {
+                        guard try BigSyncMutationTracking.requireCurrentJournalIdentity(in: realm) == identity else {
+                            throw BigSyncMutationJournalError.identityChanged
+                        }
+                        for type in types where processedTypes.insert(type.className()).inserted {
+                            foundTypes.insert(type.className())
+                            for object in realm.objects(type) {
+                                try Task.checkCancellation()
+                                guard let recovering = object as? BigSyncRestoredObjectRecovering,
+                                      let validator = object as? BigSyncOutboundSemanticObjectValidating,
+                                      let metadata = object as? ChangeMetadataRecordable else {
+                                    throw BigSyncMutationJournalError.unregisteredModel(type.className())
+                                }
+                                guard !recovering.isAwaitingRecoveryEvidence else { continue }
+                                try validator.validateOutboundSemanticObject(in: realm)
+                                try metadata.journalCurrentValuePreservingChangeMetadata(
+                                    at: timestamp, expectedJournalIdentity: identity
+                                )
+                            }
+                        }
+                        guard try BigSyncMutationTracking.requireCurrentJournalIdentity(in: realm) == identity else {
+                            throw BigSyncMutationJournalError.identityChanged
+                        }
+                    }
+                }
+                for type in reconciledObjectTypes where !foundTypes.contains(type.className()) {
+                    throw BigSyncMutationJournalError.unregisteredModel(type.className())
+                }
+            }
+        )
+    }
+}

--- a/Sources/BigSyncKit/RealmSwift/SyncedEntityProtocol.swift
+++ b/Sources/BigSyncKit/RealmSwift/SyncedEntityProtocol.swift
@@ -114,9 +114,12 @@ public extension ChangeMetadataRecordable {
     /// is a new user edit. In particular, catalog repair must not advance the
     /// broad control record's conflict clock. Application commands use the
     /// expected-identity refresh API instead.
-    internal func journalCurrentValuePreservingChangeMetadata(at timestamp: Date) throws {
+    internal func journalCurrentValuePreservingChangeMetadata(
+        at timestamp: Date,
+        expectedJournalIdentity: BigSyncMutationJournalIdentity? = nil
+    ) throws {
         _ = try recordBigSyncMutation(
-            at: timestamp, expectedJournalIdentity: nil,
+            at: timestamp, expectedJournalIdentity: expectedJournalIdentity,
             requiresAvailableIdentity: true
         )
     }

--- a/Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift
+++ b/Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift
@@ -37,7 +37,9 @@ private struct RA1DomainValue: Equatable, Sendable {
 private final class RA1OwnedRevisionObject: Object, ChangeMetadataRecordable,
     BigSyncStringEncodedIntegerModel, BigSyncInboundSemanticRecordValidating,
     BigSyncInboundSemanticReplacementValidating,
-    BigSyncOutboundSemanticObjectValidating, BigSyncRetainsSyncedTombstone {
+    BigSyncOutboundSemanticObjectValidating, BigSyncRetainsSyncedTombstone,
+    BigSyncInboundSemanticDeletionValidating, BigSyncRestoredObjectRecovering,
+    SyncSkippablePropertiesModel {
     static let bigSyncStringEncodedIntegerPropertyNames: Set<String> = [
         "stateRevision", "characters", "activeMicroseconds",
     ]
@@ -53,7 +55,30 @@ private final class RA1OwnedRevisionObject: Object, ChangeMetadataRecordable,
     @Persisted var modifiedAt = Date()
     @Persisted var explicitlyModifiedAt: Date?
     @Persisted var isDeleted = false
+    @Persisted var isAwaitingRecoveryEvidence = false
     var retainsSyncedTombstone: Bool { true }
+    func skipSyncingProperties() -> Set<String>? { ["isAwaitingRecoveryEvidence"] }
+
+    func retainForRestoreRecovery() throws {
+        guard realm?.isInWriteTransaction == true else {
+            throw BigSyncMutationJournalError.writeTransactionRequired
+        }
+        isAwaitingRecoveryEvidence = true
+    }
+
+    func admitAfterServerEvidence() throws {
+        guard realm?.isInWriteTransaction == true else {
+            throw BigSyncMutationJournalError.writeTransactionRequired
+        }
+        isAwaitingRecoveryEvidence = false
+    }
+
+    static func validateInboundSemanticDeletion(
+        _ recordID: CKRecord.ID, existingObject: Object?
+    ) throws {
+        // Retaining local tombstones alone does not reject an incoming hard delete.
+        throw RA1RevisionError.invalidPayload
+    }
 
     var domain: RA1DomainValue {
         RA1DomainValue(owner: owner, key: logicalKey, revision: stateRevision,
@@ -119,6 +144,9 @@ private final class RA1OwnedRevisionObject: Object, ChangeMetadataRecordable,
               incoming.owner == local.owner, incoming.key == local.key else {
             throw RA1RevisionError.changedIdentity
         }
+        // Copied bytes are not current authored authority. This mirrors W3's
+        // restore admission, including equal-revision server re-admission.
+        if existing.isAwaitingRecoveryEvidence { return .preferIncomingRecord }
         if incoming.revision > local.revision { return .preferIncomingRecord }
         if incoming.revision < local.revision { return .preferExistingObject }
         guard incoming == local else { throw RA1RevisionError.divergentEqualRevision }
@@ -127,6 +155,9 @@ private final class RA1OwnedRevisionObject: Object, ChangeMetadataRecordable,
     }
 
     func validateOutboundSemanticObject(in realm: Realm) throws {
+        guard !isAwaitingRecoveryEvidence else {
+            throw BigSyncSemanticAdmissionUnavailable(entityType: Self.className())
+        }
         try domain.validate()
         guard id == domain.id else { throw RA1RevisionError.changedIdentity }
         // A foreign-owned unchanged relay is allowed; it is not a new authored read.
@@ -216,10 +247,16 @@ private final class RA1RealmFixture {
     func refresh() async {
         await target.asyncRefresh()
         await tracking.asyncRefresh()
+        for realm in adapter.realmProvider?.targetReaderRealms ?? [] {
+            await realm.asyncRefresh()
+        }
     }
 
     @discardableResult
     func author(_ value: RA1DomainValue, auditTime: TimeInterval = 1_000) async throws -> String {
+        guard value.owner == journalIdentity.installationIdentifier else {
+            throw RA1RevisionError.changedIdentity
+        }
         try await target.asyncWrite {
             let object = self.target.object(ofType: RA1OwnedRevisionObject.self, forPrimaryKey: value.id)
                 ?? RA1OwnedRevisionObject()
@@ -462,6 +499,235 @@ final class OwnedRecordRevisionTests: XCTestCase {
     }
 
     @BigSyncBackgroundActor
+    func testNewerLocalRevisionAtFinalWriteOverridesSelectionSnapshot() async throws {
+        for forceSave in [false, true] {
+            let f = try await RA1RealmFixture.make()
+            _ = try await f.adapter.saveChanges(in: [f.record(mark)], forceSave: true)
+            await f.refresh()
+            var value = undo
+            value.revision = 44
+            let newest = value
+            f.adapter._testBeforeImportedRecordTargetWrite = {
+                // Same audit timestamp: only the final domain comparison can win.
+                _ = try await f.author(newest)
+            }
+            defer { f.adapter._testBeforeImportedRecordTargetWrite = nil }
+            _ = try await f.adapter.saveChanges(in: [f.record(undo)], forceSave: forceSave)
+            await f.refresh()
+            XCTAssertEqual(try f.value(), newest)
+            let upload = try await f.nextUpload()
+            XCTAssertEqual(try RA1OwnedRevisionObject.decode(upload.record), newest)
+            XCTAssertTrue(f.tracking.objects(BigSyncInboundSemanticQuarantine.self).isEmpty)
+        }
+    }
+
+    @BigSyncBackgroundActor
+    func testHigherRemoteRevisionStillWinsAfterLocalJournalChangesDuringSelection() async throws {
+        let f = try await RA1RealmFixture.make()
+        _ = try await f.author(mark)
+        let sent = try await f.nextUpload()
+        var clock = mark
+        clock.revision = 43
+        clock.activeMicroseconds = 200
+        let concurrent = clock
+        var value = undo
+        value.revision = 44
+        value.activeMicroseconds = 250
+        let newest = value
+        f.adapter._testBeforeImportedRecordTargetWrite = {
+            _ = try await f.author(concurrent, auditTime: 99_000)
+        }
+        defer { f.adapter._testBeforeImportedRecordTargetWrite = nil }
+        _ = try await f.adapter.saveChanges(in: [f.record(newest, auditTime: 10)], forceSave: false)
+        await f.refresh()
+        let generation = try XCTUnwrap(f.generation())
+        XCTAssertEqual(try f.value(), newest)
+        try await f.acknowledge(sent)
+        XCTAssertEqual(f.generation(), generation)
+        let upload = try await f.nextUpload()
+        XCTAssertEqual(try RA1OwnedRevisionObject.decode(upload.record), newest)
+    }
+
+    @BigSyncBackgroundActor
+    func testEqualRevisionDivergenceAtFinalWriteCannotBeHiddenByNewPendingWork() async throws {
+        let f = try await RA1RealmFixture.make()
+        _ = try await f.adapter.saveChanges(in: [f.record(mark)], forceSave: true)
+        await f.refresh()
+        var value = undo
+        value.activeMicroseconds = 200
+        let concurrent = value
+        f.adapter._testBeforeImportedRecordTargetWrite = { _ = try await f.author(concurrent) }
+        defer { f.adapter._testBeforeImportedRecordTargetWrite = nil }
+        let results = try await f.adapter.saveChanges(in: [f.record(undo)], forceSave: false)
+        await f.refresh()
+        guard let result = results.first, case .quarantined = result.disposition else {
+            return XCTFail("Final-write equality must be checked before pending-local preservation")
+        }
+        XCTAssertEqual(try f.value(), concurrent)
+        XCTAssertNotNil(f.generation())
+        XCTAssertEqual(f.tracking.objects(BigSyncInboundSemanticQuarantine.self).count, 1)
+    }
+
+    @BigSyncBackgroundActor
+    func testSecondIncomingWinnerJournalFailureRollsBackBothTargets() async throws {
+        let f = try await RA1RealmFixture.make()
+        var other = mark
+        other.key = "article-a:page-1"
+        let firstGeneration = try await f.author(mark)
+        let secondGeneration = try await f.author(other)
+        _ = try await f.prepared()
+        var otherUndo = undo
+        otherUndo.key = other.key
+        let failure = RA1IdentityFailure(identity: f.journalIdentity, failsOnCall: 2)
+        BigSyncMutationPolicy(excludedClassNames: []).install(configurations: [f.target.configuration],
+            mutationJournalIdentityProvider: { failure.next() })
+        do {
+            _ = try await f.adapter.saveChanges(in: [f.record(undo), f.record(otherUndo)], forceSave: true)
+            XCTFail("The second required journal failure must escape the whole target write")
+        } catch BigSyncMutationJournalError.identityUnavailable { }
+        XCTAssertEqual(failure.callCount, 2)
+        await f.refresh()
+        XCTAssertEqual(try f.value(), mark)
+        XCTAssertEqual(try f.value(other.id), other)
+        XCTAssertEqual(f.generation(), firstGeneration)
+        XCTAssertEqual(f.generation(other.id), secondGeneration)
+        XCTAssertTrue(f.tracking.objects(BigSyncInboundSemanticQuarantine.self).isEmpty)
+        try await f.bind(f.journalIdentity, scope: f.scope)
+        _ = try await f.adapter.saveChanges(in: [f.record(undo), f.record(otherUndo)], forceSave: true)
+        await f.refresh()
+        XCTAssertEqual(try f.value(), undo)
+        XCTAssertEqual(try f.value(other.id), otherUndo)
+        XCTAssertNotEqual(f.generation(), firstGeneration)
+        XCTAssertNotEqual(f.generation(other.id), secondGeneration)
+    }
+
+    @BigSyncBackgroundActor
+    func testTrackingFailureAfterTargetCommitPreservesWinnerForReplayAndOldAck() async throws {
+        let f = try await RA1RealmFixture.make()
+        _ = try await f.author(mark)
+        let sent = try await f.nextUpload()
+        f.adapter._testBeforeImportedRecordPersistenceWrite = { throw RA1RevisionError.unexpectedIO }
+        defer { f.adapter._testBeforeImportedRecordPersistenceWrite = nil }
+        do {
+            _ = try await f.adapter.saveChanges(in: [f.record(undo)], forceSave: true)
+            XCTFail("Expected the failure between the two physical Realm commits")
+        } catch RA1RevisionError.unexpectedIO { }
+        await f.refresh()
+        let winnerGeneration = try XCTUnwrap(f.generation())
+        XCTAssertEqual(try f.value(), undo, "Target committed; tracking failure is not a target rollback")
+        XCTAssertNotEqual(winnerGeneration, sent.generation)
+        f.adapter._testBeforeImportedRecordPersistenceWrite = nil
+        try await f.acknowledge(sent)
+        XCTAssertEqual(f.generation(), winnerGeneration)
+        _ = try await f.adapter.saveChanges(in: [f.record(undo)], forceSave: false)
+        await f.refresh()
+        XCTAssertEqual(f.generation(), winnerGeneration, "Equal replay must not mint another domain edit")
+        let retry = try await f.nextUpload()
+        XCTAssertEqual(try RA1OwnedRevisionObject.decode(retry.record), undo)
+        try await f.acknowledge(retry)
+        XCTAssertNil(f.generation())
+    }
+
+    @BigSyncBackgroundActor
+    func testPayloadAheadOfForwardedGenerationStillDrainsNewerJournal() async throws {
+        let f = try await RA1RealmFixture.make()
+        let g1 = try await f.author(mark)
+        _ = try await f.nextUpload()
+        let g2 = try await f.author(undo)
+        // No fixture forward here: exercise the real materialization/ack window.
+        let prepared = try await f.adapter.preparedRecordsToUpload(limit: 1, restrictedToEntityType: nil)
+        let retry = try XCTUnwrap(prepared.first)
+        XCTAssertEqual(retry.generation, g1)
+        XCTAssertEqual(try RA1OwnedRevisionObject.decode(retry.record), undo)
+        try await f.acknowledge(retry)
+        XCTAssertEqual(f.generation(), g2)
+        let remaining = try await f.adapter.preparedRecordsToUpload(limit: 1, restrictedToEntityType: nil)
+        let final = try XCTUnwrap(remaining.first)
+        XCTAssertEqual(final.generation, g2)
+        XCTAssertEqual(try RA1OwnedRevisionObject.decode(final.record), undo)
+        try await f.acknowledge(final)
+        XCTAssertNil(f.generation())
+    }
+
+    @BigSyncBackgroundActor
+    func testDivergentOwnEchoIsQuarantinedWithoutApplyingOrAcknowledgingIt() async throws {
+        let f = try await RA1RealmFixture.make()
+        let generation = try await f.author(undo)
+        var divergent = undo
+        divergent.title = "Different authored title at the same revision"
+        let results = try await f.adapter.validateAuthoritativeOwnUploadRecords([f.record(divergent)])
+        await f.refresh()
+        guard let result = results.first, case .quarantined = result.disposition else {
+            return XCTFail("Own-echo validation must not bypass domain equality")
+        }
+        XCTAssertEqual(try f.value(), undo)
+        XCTAssertEqual(f.generation(), generation)
+    }
+
+    @BigSyncBackgroundActor
+    func testIncomingHardDeletionCannotEraseAcknowledgedEmptyRevision() async throws {
+        for deleted in [false, true] {
+            let f = try await RA1RealmFixture.make()
+            var value = undo
+            value.deleted = deleted
+            _ = try await f.author(value)
+            let upload = try await f.nextUpload()
+            try await f.acknowledge(upload)
+            let results = try await f.adapter.deleteRecords(with: [upload.record.recordID])
+            await f.refresh()
+            guard let result = results.first, case .quarantined = result.disposition else {
+                return XCTFail("Retained version requires model deletion admission as well as a live upsert")
+            }
+            XCTAssertEqual(try f.value(), value)
+            XCTAssertNil(f.generation())
+            _ = try await f.adapter.saveChanges(in: [f.record(mark)], forceSave: true)
+            await f.refresh()
+            let repair = try await f.nextUpload()
+            XCTAssertEqual(try RA1OwnedRevisionObject.decode(repair.record), value)
+        }
+    }
+
+    @BigSyncBackgroundActor
+    func testBackupRestoreWithholdsCopiedRowsUntilActualServerImport() async throws {
+        var newer = undo
+        newer.revision = 44
+        let serverValues: [RA1DomainValue?] = [nil, mark, undo, newer]
+        for server in serverValues {
+            let f = try await RA1RealmFixture.make()
+            _ = try await f.author(undo)
+            _ = try await f.nextUpload()
+            let replacement = BigSyncMutationJournalIdentity(installationIdentifier: "restored-installation",
+                replicaBindingGenerationIdentifier: String(repeating: "b", count: 64))
+            try await f.bind(replacement, scope: f.scope)
+            let epoch = 4_000_000_002
+            try await f.adapter.prepareChangeFeedReset(accountScopeIdentifier: f.scope, epoch: epoch,
+                                                       mode: .backupRestore)
+            await f.refresh()
+            let copy = try XCTUnwrap(f.target.object(ofType: RA1OwnedRevisionObject.self, forPrimaryKey: undo.id))
+            XCTAssertTrue(copy.isAwaitingRecoveryEvidence)
+            XCTAssertEqual(copy.domain, undo)
+            XCTAssertNil(f.generation(), "Copied upload work is not a new installation's intent")
+            try await f.adapter.beginChangeFeedServerBootstrap(accountScopeIdentifier: f.scope, epoch: epoch,
+                                                               mode: .backupRestore)
+            if let server {
+                _ = try await f.adapter.validateAuthoritativeOwnUploadRecords([f.record(server)])
+                await f.refresh()
+                XCTAssertTrue(copy.isAwaitingRecoveryEvidence, "Validation-only echoes cannot admit copied bytes")
+                _ = try await f.adapter.saveChanges(in: [f.record(server)], forceSave: true)
+            }
+            try await f.adapter.reconcileAfterChangeFeedServerBootstrap(accountScopeIdentifier: f.scope,
+                                                                         epoch: epoch, mode: .backupRestore)
+            await f.refresh()
+            XCTAssertEqual(copy.isAwaitingRecoveryEvidence, server == nil)
+            XCTAssertEqual(copy.domain, server ?? undo)
+            XCTAssertEqual(copy.owner, "owner-a")
+            XCTAssertNil(f.generation())
+            let uploads = try await f.prepared()
+            XCTAssertTrue(uploads.isEmpty, "Restore neither reauthors original ownership nor resurrects absent data")
+        }
+    }
+
+    @BigSyncBackgroundActor
     private func exerciseConflictLoop(local: RA1DomainValue, server: RA1DomainValue,
                                       expected: RA1DomainValue) async throws {
         let f = try await RA1RealmFixture.make()
@@ -488,12 +754,27 @@ final class OwnedRecordRevisionTests: XCTestCase {
             runID: sync.synchronizationRunID, accountIdentifier: account,
             accountScopeIdentifier: lease.accountScopeIdentifier,
             replicaBindingGenerationIdentifier: binding, accountInvalidationGeneration: lease.invalidationGeneration)
-        _ = try await f.author(local)
+        // Seed an unchanged foreign value through inbound replication, then make
+        // it a normal repair upload. Do not author owner-a with this random
+        // installation's identity merely to arrange the transport fixture.
+        _ = try await f.adapter.saveChanges(in: [f.record(local)], forceSave: true)
+        var stale = local
+        stale.revision -= 1
+        _ = try await f.adapter.saveChanges(in: [f.record(stale)], forceSave: true)
+        await f.refresh()
         _ = try await f.prepared()
+        // Keep journal forwarding paused. An incoming preference can replace G1
+        // with G2 in the target while the tracking cache still knows only G1.
+        // Refresh values at that boundary without manually forwarding G2.
+        f.adapter._testBeforeImportedRecordPersistenceWrite = { await f.refresh() }
+        defer { f.adapter._testBeforeImportedRecordPersistenceWrite = nil }
         try await sync.synchronizeAdapter(f.adapter)
         await f.refresh()
         let uploads = await io.uploadedValues()
-        XCTAssertEqual(uploads, [local, expected])
+        XCTAssertEqual(uploads.first, local)
+        XCTAssertTrue((2...3).contains(uploads.count))
+        XCTAssertTrue(uploads.dropFirst().allSatisfy { $0 == expected },
+                      "Every retry must transport the selected complete domain value")
         XCTAssertEqual(try f.value(), expected)
         XCTAssertNil(f.generation(), "Retry must reach real generation acknowledgement")
         XCTAssertTrue(f.tracking.objects(BigSyncInboundSemanticQuarantine.self).isEmpty)
@@ -502,8 +783,9 @@ final class OwnedRecordRevisionTests: XCTestCase {
     }
 }
 
-// Deliberately bounded remote script: exactly one serverRecordChanged followed
-// by one successful retry. Unexpected operations throw rather than succeeding.
+// One conflict, then at most two saves of the selected value. G1 may acknowledge
+// a retry before the replacement G2 reaches tracking; G2 must then drain too.
+// This is not a CloudKit change-tag/CAS simulator (records have no server tags).
 private actor RA1MutationScript {
     let conflict: CKRecord
     var uploads: [RA1DomainValue] = []
@@ -511,7 +793,7 @@ private actor RA1MutationScript {
     func modify(_ records: [CKRecord], deleting: [CKRecord.ID],
                 savePolicy: CKModifyRecordsOperation.RecordSavePolicy, atomically: Bool) throws -> CloudKitRecordMutationResults {
         guard records.count == 1, deleting.isEmpty, !atomically,
-              savePolicy == .ifServerRecordUnchanged, uploads.count < 2,
+              savePolicy == .ifServerRecordUnchanged, uploads.count < 3,
               records[0].recordID == conflict.recordID else { throw RA1RevisionError.unexpectedIO }
         let record = records[0]
         uploads.append(try RA1OwnedRevisionObject.decode(record))
@@ -546,6 +828,32 @@ private final class RA1ScriptedIO: NSObject, CloudKitDatabaseAdapter, CloudKitRe
     func recordZoneChanges(in id: CKRecordZone.ID, since cursor: RecordZoneChangeCursor?,
                            desiredKeys: [CKRecord.FieldKey]?, resultsLimit: Int?) async throws -> CloudKitRecordZoneChangePage {
         throw RA1RevisionError.unexpectedIO
+    }
+}
+
+// Faults only the existing journal identity provider, never Realm rollback.
+private final class RA1IdentityFailure: @unchecked Sendable {
+    private let lock = NSLock()
+    private let identity: BigSyncMutationJournalIdentity
+    private let failsOnCall: Int
+    private var calls = 0
+
+    init(identity: BigSyncMutationJournalIdentity, failsOnCall: Int) {
+        self.identity = identity
+        self.failsOnCall = failsOnCall
+    }
+
+    var callCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return calls
+    }
+
+    func next() -> BigSyncMutationJournalIdentity? {
+        lock.lock()
+        defer { lock.unlock() }
+        calls += 1
+        return calls == failsOnCall ? nil : identity
     }
 }
 


### PR DESCRIPTION
## W2 code continuation — published; cutover removal still caller-dependent

BigSync-only ownership. Coordinator aehlke/manabi-reader#21. Work branch `codex/reading-analytics-w2-review-20260911`, target `codex/reading-analytics-integration-20260911`.

- Preserved integration base: `5923cdccc39d90952865d27041ee7ac1168a1ac8`.
- Current head: **`978ddc372f2420c4ff4ff12c53a78a2f7b4317f6`**.
- Latest production commit: **`634aed9f2ff52a39275f11004a909be3deea0599`**, parent `0e7c9f1ed8f7d1dd74d66d7982afad8bf0d0f2cc`.
- Prior reconciled-restore implementation: `95e25ba7119733e0fb91e3ff17a5bd12846d2b55`.

### Latest actual code corrections

1. `BigSyncClientIdentityLeaseRegistry` rejects recursive preparation/shared retention and nested exclusive restore acquisition before changing the outer exclusive file lease. The recursive mutex still permits read-only current-identity access. This prevents early LOCK_EX downgrade and nested cleanup from releasing an enclosing restore.
2. Manual restore event identity uses the existing full receipt decoder, not merely a header and third-line UUID. Truncated or unknown required manual contracts stay invalid; complete old receipts and automatic UUID events retain their format.
3. `prepareInstallation`, `currentInstallationIdentifier`, and restore-event acknowledgement require the matching completed receipt for a reconciled event even when its optional intent is missing. A new sentinel or absent intent alone cannot grant completed journal repair. Acknowledgement also checks that event's new installation.

Two existing production files **+53/-17**, no new API/model/file/lock/phase/journal or tests. Blob identities: BackupDetection `45c500359719d4fec3e4bc3b44dc10a012e98549`; BigSyncClientIdentity `d7cabf070976060fab43cfd7f8e87aef01a0ee74`.

### Restore caller join is now present in owner source

The former missing-binding report is obsolete. W8 Common `190d5d5d5ad5ec510086c1e4aa57a76c8f64508d` registers the live provider and calls the actual `withReconciledManualBackupRestore` extension. W8 Core `0296c8c4620d66d4b47974368d52916c8176415f` invokes that Common path from the production backup manager. W3 policy at Common `9dccf505cf2799f94ac0a4538b235708f6a9686c` also delegates to it and removes the old blanket normalizer. W1 must still compose these source floors; no physical restore run is claimed.

The helper uses the existing exclusive lease/durable intent/event/receipt to publish the new identity and journal ONLY independently known admitted records as unchanged repairs. Actual backupRestore preserves current-identity journals. Original owner/stateRevision/domain/audit values remain unchanged; backup-only rows remain withheld. Required repair cannot be skipped by raw retry; post-event failure keeps handoffPending. Completed intent cleanup does not repeat replacement or repair. No new restore mode, floor registry, second upload ledger or cloud baseline mutation API.

Earlier code retains the save/delete/upload/zone single-delivery fixes and original-account/run checks after zone failures. Model preferences, generation acknowledgements, partial results, physical request leases and replay remain intact.

### Evidence and exact scope

**Per Alex, this pass ran no tests, compiler/typecheck, syntax checks, native tooling or CloudKit operations.** Only source/hash/diff/ref checks were used for safe publication. These source-grounded defects are not represented as native-reproduced failures.

The 21 real-Realm methods remain unchanged and unrun. They exercise the actual adapter/journal and two synchronizeAdapter loops with remote IO scripted, not Common or the complete physical manual restore. The older fixture's permissive restored selector is not W3's corrected policy. Existing callback/account/partial-result regressions remain, not claimed rerun.

Cumulative PR production vs5923: **+357/-117 across six source files**, including the earlier104-line helper. Prior test refinement+314/-6 unchanged. Docs separate; no identical moves, manifests or workflows. No cap waiver or new architecture.

### Remaining implementation boundary

**No cutover export removed.** Re-read actual `ReaderOrderedV2BigSyncTransport` at live W6 `1fa7174e`: acquire still calls beginPostBarrierOutboundQuiescence and establishPostBarrierDrain; source/recovery callers remain. W8/W3 retirement does not close those W6 calls. Required caller-removal SHAs are still needed before accepted-head/final-drain/source/paused-recovery exports and exclusive probe/script references can be deleted together. The prior235-line prepared source-only patch is unapplied and not counted as reduction or full cleanup.

Ordinary outbound admission, submitted-operation identity, exact replay and checkpoint decoding must remain. No missing proxy, intent, journal, timeout or lost lock is settlement evidence. No success-shaped compatibility alias. W1's cloud-election/CAS/publication deferral and W8's withdrawn raw-save request remain in force.

Detailed APIs, exact21 method IDs, current caller floors and retained/removal inventory are in Documentation/ReadingAnalyticsWorker2.md. Keep draft. W1 alone approves/merges integration; no integration/default/release merge, force push, live migration/baseline selection, account/zone/journal clearing, activation, foreign source or Mac worktree edit.