### PR TITLE
Replay stale inbound targets through the existing attempt-fenced retry

### DIFF
--- a/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+RecordMutations.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+RecordMutations.swift
@@ -294,8 +294,14 @@ extension CloudKitSynchronizer {
                records.count >= requestedBatchSize {
                 increaseBatchSize()
             }
+            // A successful acknowledgement can forward a newer target journal
+            // generation into tracking. A short batch is therefore not proof of
+            // quiescence. Give newly published record work another preparation
+            // turn; deletion-only or differently restricted work yields an empty
+            // record batch and returns immediately to its owning phase.
             guard handledFailures > 0
-                    || records.count >= requestedBatchSize else { return }
+                    || records.count >= requestedBatchSize
+                    || adapter.hasChanges else { return }
             await Task.yield()
         }
     }
@@ -454,7 +460,13 @@ extension CloudKitSynchronizer {
             if handledFailures == 0, recordIDs.count >= requestedBatchSize {
                 increaseBatchSize()
             }
-            guard handledFailures > 0 || recordIDs.count >= requestedBatchSize else { return }
+            // Deletion acknowledgement has the same journal-forwarding
+            // semantics as upload acknowledgement. If it exposes a newer
+            // deletion generation, consume it in this owned deletion drain
+            // instead of deferring it solely because the prior batch was short.
+            guard handledFailures > 0
+                    || recordIDs.count >= requestedBatchSize
+                    || adapter.hasChanges else { return }
             await Task.yield()
         }
     }

--- a/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+Sync.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+Sync.swift
@@ -479,7 +479,13 @@ extension CloudKitSynchronizer {
         let terminalZoneDeletionKind = (error as? ChangeFeedMigrationError)?
             .deletionKind
 
-        if let migrationError = error as? ChangeFeedMigrationError,
+        if error is RealmSwiftInboundTargetChangedError {
+            // A non-journaled local write invalidated an inbound selection.
+            // The inbound page/cursor was not committed, so replay through an
+            // ordinary delayed synchronization rather than terminating the drain.
+            shouldRetry = true
+            retryDelay = 1
+        } else if let migrationError = error as? ChangeFeedMigrationError,
            migrationError.deletionKind == .encryptedDataReset {
             // The database-history event already persisted a dedicated
             // recovery request. Retry immediately; the next attempt performs

--- a/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer.swift
@@ -3466,6 +3466,28 @@ public class CloudKitSynchronizer: NSObject {
                 databaseScope: database.databaseScope,
                 recordZoneID: adapter.recordZoneID
             )
+            // The initializer created backup/installation state for the original
+            // zone. This legacy DEBUG fixture hook must initialize the rebound
+            // namespace too; ordinary outbound admission still requires its
+            // real installation sentinel and must never bypass that proof.
+            do {
+                let result = try BackupDetection.run(
+                    store: keyValueStore,
+                    namespace: durableStateNamespace,
+                    sharedSentinelBaseURL: backupDetectionBaseURL
+                )
+                refreshBackupRestoreRequirement()
+                if result == .restoredFromBackup || backupRestoreDetected {
+                    accountScopeAuthorityFence.poison()
+                    clearDeviceIdentifier()
+                    try invalidateAccountScopeLeaseDurably()
+                    queueAccountScopeInvalidation(.restoreDetected)
+                }
+            } catch {
+                accountScopeAuthorityFence.poison()
+                backupDetectionError = error
+                logger.error("QSCloudKitSynchronizer >> Rebound fixture backup detection failed: \(error)")
+            }
         }
         allowsRecordZoneRebindingForTesting = false
 #endif

--- a/Tests/BigSyncKitTests/BigSyncKitTests.swift
+++ b/Tests/BigSyncKitTests/BigSyncKitTests.swift
@@ -560,6 +560,8 @@ private final class FakeModelAdapter:
     var resetSyncCachesHandler: (@Sendable () async throws -> Void)?
     var saveChangesHandler: (@Sendable () async throws -> Void)?
     var recordsToUploadHandler: (@Sendable () async throws -> Void)?
+    @BigSyncBackgroundActor var didDeleteHandler:
+        (@BigSyncBackgroundActor @Sendable () async throws -> Void)?
     var terminalPendingChanges = false
     var semanticBlockers = [CloudKitSynchronizer.DomainBlocker]()
     var domainHookInvocationCount = 0
@@ -585,6 +587,11 @@ private final class FakeModelAdapter:
         self.priorityEntityTypeNames = priorities
         self.uploadedByEntity = uploadedByEntity
         self.deletedByEntity = deletedByEntity
+    }
+
+    @BigSyncBackgroundActor
+    func enqueueDeletion(_ recordID: CKRecord.ID, entityType: String) {
+        deletedByEntity[entityType, default: []].append(recordID)
     }
 
     func cleanUp() async throws {
@@ -689,6 +696,7 @@ private final class FakeModelAdapter:
     ) async throws {
         let recordNames = recordIDs.map { $0.recordName }.joined(separator: ",")
         events.append("didDelete:\(recordNames)")
+        try await didDeleteHandler?()
         if repeatsPreparedDeletions {
             let acknowledged = Set(recordIDs)
             for entityType in deletedByEntity.keys {
@@ -16138,6 +16146,67 @@ final class BigSyncKitTests: XCTestCase {
     ) async throws {
         try await prepareDirectOutboundAuthority(synchronizer)
         try await synchronizer.synchronizeAdapter(adapter)
+    }
+
+    @BigSyncBackgroundActor
+    func testReboundFixtureInitializesItsActualOutboundNamespace() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rebound-outbound-" + UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let synchronizer = makeSynchronizer(backupDetectionBaseURL: root)
+        let initialNamespace = synchronizer.durableStateNamespace
+        let initialInstallation = try XCTUnwrap(BackupDetection.installationIdentifier(
+            namespace: initialNamespace, sharedSentinelBaseURL: root))
+        let adapter = FakeModelAdapter(
+            zoneID: CKRecordZone.ID(zoneName: "rebound-outbound-zone"), priorities: [])
+        synchronizer.addModelAdapter(adapter)
+        let selectedNamespace = synchronizer.durableStateNamespace
+        XCTAssertNotEqual(selectedNamespace, initialNamespace)
+        let selectedInstallation = try XCTUnwrap(BackupDetection.installationIdentifier(
+            namespace: selectedNamespace, sharedSentinelBaseURL: root))
+        XCTAssertEqual(BackupDetection.installationIdentifier(
+            namespace: initialNamespace, sharedSentinelBaseURL: root), initialInstallation)
+        try await prepareDirectOutboundAuthority(synchronizer)
+        let context = try XCTUnwrap(synchronizer.activeRunContext)
+        let principal = try synchronizer.currentOutboundPrincipal(for: context)
+        XCTAssertEqual(principal.installationIdentifier, selectedInstallation)
+        XCTAssertEqual(principal.durableStateNamespace, selectedNamespace)
+        // The fix initializes real evidence; it must not relax its admission.
+        try FileManager.default.removeItem(at: root)
+        XCTAssertThrowsError(try synchronizer.currentOutboundPrincipal(for: context)) {
+            XCTAssertEqual($0 as? BigSyncOutboundQuiescenceError, .staleAuthority)
+        }
+    }
+
+    @BigSyncBackgroundActor
+    func testDeletionAcknowledgementCreatedDeletionDrainsInSameAdapterPass() async throws {
+        let database = FakeCloudKitDatabase()
+        let zoneID = CKRecordZone.ID(
+            zoneName: "ack-created-deletion-zone",
+            ownerName: CKCurrentUserDefaultName
+        )
+        let first = CKRecord.ID(recordName: "Bookmark.first", zoneID: zoneID)
+        let second = CKRecord.ID(recordName: "Bookmark.second", zoneID: zoneID)
+        let adapter = FakeModelAdapter(
+            zoneID: zoneID,
+            priorities: [],
+            deletedByEntity: ["Bookmark": [first]]
+        )
+        adapter.didDeleteHandler = {
+            adapter.didDeleteHandler = nil
+            adapter.enqueueDeletion(second, entityType: "Bookmark")
+        }
+        let synchronizer = makeSynchronizer(database: database)
+        synchronizer.addModelAdapter(adapter)
+
+        try await synchronizeAdapterWithOutboundAuthority(synchronizer, adapter)
+
+        XCTAssertEqual(database.modifyRecordsOperationCount, 2)
+        XCTAssertEqual(
+            adapter.events.filter { $0.hasPrefix("didDelete:") },
+            ["didDelete:Bookmark.first", "didDelete:Bookmark.second"]
+        )
+        XCTAssertFalse(adapter.hasChanges)
     }
 
     @BigSyncBackgroundActor

--- a/Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift
+++ b/Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift
@@ -754,6 +754,17 @@ final class OwnedRecordRevisionTests: XCTestCase {
             runID: sync.synchronizationRunID, accountIdentifier: account,
             accountScopeIdentifier: lease.accountScopeIdentifier,
             replicaBindingGenerationIdentifier: binding, accountInvalidationGeneration: lease.invalidationGeneration)
+        // This helper owns a direct adapter drain, not a background full sync.
+        // Mirror the enclosing production drain's ownership so normal journal
+        // delegate wakeups coalesce instead of starting a second attempt that
+        // the deliberately upload-only transport cannot service.
+        let attemptID = sync.synchronizationAttemptID
+        sync.syncing = true
+        sync.synchronizationDrainIsActive = true
+        defer {
+            sync.cancelSynchronization()
+            try? FileManager.default.removeItem(at: root)
+        }
         // Seed an unchanged foreign value through inbound replication, then make
         // it a normal repair upload. Do not author owner-a with this random
         // installation's identity merely to arrange the transport fixture.
@@ -771,6 +782,10 @@ final class OwnedRecordRevisionTests: XCTestCase {
         try await sync.synchronizeAdapter(f.adapter)
         await f.refresh()
         let uploads = await io.uploadedValues()
+        XCTAssertEqual(sync.synchronizationAttemptID, attemptID,
+                       "A journal wakeup must not replace the owned direct drain")
+        XCTAssertTrue(sync.syncing)
+        XCTAssertNil(sync.synchronizationTask)
         XCTAssertEqual(uploads.first, local)
         XCTAssertTrue((2...3).contains(uploads.count))
         XCTAssertTrue(uploads.dropFirst().allSatisfy { $0 == expected },

--- a/Tests/BigSyncKitTests/RA1InboundReplayTests.swift
+++ b/Tests/BigSyncKitTests/RA1InboundReplayTests.swift
@@ -1,0 +1,175 @@
+import CloudKit
+import Foundation
+import Logging
+import XCTest
+@testable import BigSyncKit
+
+private enum ReplayProbeError: Error { case unexpectedTransport, terminal }
+
+// Deliberately has no CKContainer or network-backed implementation.
+private final class ReplayProbeTransport: NSObject,
+    CloudKitDatabaseAdapter, CloudKitChangeFeed,
+    CloudKitSubscriptionStore, CloudKitZoneStore, CloudKitRecordStore,
+    @unchecked Sendable {
+    var databaseScope: CKDatabase.Scope { .private }
+    func subscription(withID identifier: CKSubscription.ID) async throws -> CKSubscription? {
+        throw ReplayProbeError.unexpectedTransport
+    }
+    func save(subscription: CKSubscription) async throws -> CKSubscription {
+        throw ReplayProbeError.unexpectedTransport
+    }
+    func deleteSubscription(withID identifier: CKSubscription.ID) async throws {
+        throw ReplayProbeError.unexpectedTransport
+    }
+    func recordZone(withID identifier: CKRecordZone.ID) async throws -> CKRecordZone {
+        throw ReplayProbeError.unexpectedTransport
+    }
+    func save(recordZone: CKRecordZone) async throws -> CKRecordZone {
+        throw ReplayProbeError.unexpectedTransport
+    }
+    func deleteRecordZone(withID identifier: CKRecordZone.ID) async throws {
+        throw ReplayProbeError.unexpectedTransport
+    }
+    func modifyRecords(
+        saving recordsToSave: [CKRecord],
+        deleting recordIDsToDelete: [CKRecord.ID],
+        savePolicy: CKModifyRecordsOperation.RecordSavePolicy,
+        atomically: Bool
+    ) async throws -> CloudKitRecordMutationResults {
+        throw ReplayProbeError.unexpectedTransport
+    }
+    func databaseChanges(
+        since cursor: DatabaseChangeCursor?, resultsLimit: Int?
+    ) async throws -> CloudKitDatabaseChangePage {
+        throw ReplayProbeError.unexpectedTransport
+    }
+    func recordZoneChanges(
+        in zoneID: CKRecordZone.ID, since cursor: RecordZoneChangeCursor?,
+        desiredKeys: [CKRecord.FieldKey]?, resultsLimit: Int?
+    ) async throws -> CloudKitRecordZoneChangePage {
+        throw ReplayProbeError.unexpectedTransport
+    }
+}
+
+private final class ReplayProbeStore: NSObject, KeyValueStore {
+    private var values = [String: Any]()
+    func object(forKey key: String) -> Any? { values[key] }
+    func bool(forKey key: String) -> Bool { values[key] as? Bool ?? false }
+    func set(value: Any?, forKey key: String) { values[key] = value }
+    func set(boolValue: Bool, forKey key: String) { values[key] = boolValue }
+    func removeObject(forKey key: String) { values.removeValue(forKey: key) }
+    func synchronize() -> Bool { true }
+}
+
+final class RA1InboundReplayTests: XCTestCase {
+    @BigSyncBackgroundActor
+    private func makeSynchronizer() -> (CloudKitSynchronizer, URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RA1InboundReplay-\(UUID().uuidString)", isDirectory: true)
+        let synchronizer = CloudKitSynchronizer(
+            identifier: UUID().uuidString,
+            containerIdentifier: "iCloud.RA1InboundReplay.offline",
+            database: ReplayProbeTransport(),
+            recordZoneID: CKRecordZone.ID(zoneName: "RA1InboundReplay", ownerName: CKCurrentUserDefaultName),
+            keyValueStore: ReplayProbeStore(),
+            accountIdentifierProvider: { throw ReplayProbeError.unexpectedTransport },
+            accountStatusProvider: { throw ReplayProbeError.unexpectedTransport },
+            backupDetectionBaseURL: directory,
+            logger: Logger(label: "RA1InboundReplayTests")
+        )
+        return (synchronizer, directory)
+    }
+
+    @BigSyncBackgroundActor
+    func testInboundTargetRaceSchedulesBoundedOrdinaryReplay() async throws {
+        let (synchronizer, directory) = makeSynchronizer()
+        defer {
+            synchronizer.cancelSynchronization()
+            try? FileManager.default.removeItem(at: directory)
+        }
+        synchronizer.syncing = true
+        synchronizer.synchronizationDrainIsActive = true
+        let attemptID = synchronizer.synchronizationAttemptID
+        let started = Date()
+        await synchronizer.failSynchronization(error:
+            RealmSwiftInboundTargetChangedError(recordName: "RA1ParityRecord.collision"))
+        let completed = Date()
+
+        let assertionValue1 = synchronizer.synchronizationAttemptID
+        XCTAssertEqual(assertionValue1, attemptID)
+        let assertionValue2 = synchronizer.syncing
+        XCTAssertTrue(assertionValue2)
+        let assertionValue3 = synchronizer.synchronizationDrainIsActive
+        XCTAssertTrue(assertionValue3)
+        let assertionValue4 = synchronizer.synchronizationTask
+        XCTAssertNotNil(assertionValue4)
+        let assertionValue5 = synchronizer.retrySleepUntil
+        let retryAt = try XCTUnwrap(assertionValue5)
+        XCTAssertGreaterThanOrEqual(retryAt, started.addingTimeInterval(1))
+        XCTAssertLessThanOrEqual(retryAt, completed.addingTimeInterval(1))
+        let assertionValue6 = synchronizer.consecutiveTransientCloudKitFailures
+        XCTAssertEqual(assertionValue6, 0)
+        await synchronizer.cancelSynchronizationAndWait()
+    }
+
+    @BigSyncBackgroundActor
+    func testCancellationRevokesScheduledInboundReplay() async throws {
+        let (synchronizer, directory) = makeSynchronizer()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        synchronizer.syncing = true
+        synchronizer.synchronizationDrainIsActive = true
+        await synchronizer.failSynchronization(error:
+            RealmSwiftInboundTargetChangedError(recordName: "RA1ParityRecord.collision"))
+        let assertionValue7 = synchronizer.retrySleepUntil
+        XCTAssertNotNil(assertionValue7)
+        await synchronizer.cancelSynchronizationAndWait()
+        let cancelledAttempt = synchronizer.synchronizationAttemptID
+        try await Task.sleep(nanoseconds: 1_100_000_000)
+        let assertionValue8 = synchronizer.synchronizationAttemptID
+        XCTAssertEqual(assertionValue8, cancelledAttempt)
+        let assertionValue9 = synchronizer.syncing
+        XCTAssertFalse(assertionValue9)
+        let assertionValue10 = synchronizer.synchronizationDrainIsActive
+        XCTAssertFalse(assertionValue10)
+        let assertionValue11 = synchronizer.retrySleepUntil
+        XCTAssertNil(assertionValue11)
+        let assertionValue12 = synchronizer.synchronizationTask
+        XCTAssertNil(assertionValue12)
+    }
+
+    @BigSyncBackgroundActor
+    func testAlreadyCancelledRaceDoesNotScheduleReplay() async throws {
+        let (synchronizer, directory) = makeSynchronizer()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        synchronizer.syncing = true
+        synchronizer.synchronizationDrainIsActive = true
+        synchronizer.cancelSync = true
+        await synchronizer.failSynchronization(error:
+            RealmSwiftInboundTargetChangedError(recordName: "RA1ParityRecord.collision"))
+        let assertionValue13 = synchronizer.syncing
+        XCTAssertFalse(assertionValue13)
+        let assertionValue14 = synchronizer.synchronizationDrainIsActive
+        XCTAssertFalse(assertionValue14)
+        let assertionValue15 = synchronizer.retrySleepUntil
+        XCTAssertNil(assertionValue15)
+        let assertionValue16 = synchronizer.synchronizationTask
+        XCTAssertNil(assertionValue16)
+    }
+
+    @BigSyncBackgroundActor
+    func testUnrelatedTerminalFailureDoesNotBecomeReplay() async throws {
+        let (synchronizer, directory) = makeSynchronizer()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        synchronizer.syncing = true
+        synchronizer.synchronizationDrainIsActive = true
+        await synchronizer.failSynchronization(error: ReplayProbeError.terminal)
+        let assertionValue17 = synchronizer.syncing
+        XCTAssertFalse(assertionValue17)
+        let assertionValue18 = synchronizer.synchronizationDrainIsActive
+        XCTAssertFalse(assertionValue18)
+        let assertionValue19 = synchronizer.retrySleepUntil
+        XCTAssertNil(assertionValue19)
+        let assertionValue20 = synchronizer.synchronizationTask
+        XCTAssertNil(assertionValue20)
+    }
+}


### PR DESCRIPTION
## Exact selected source lineage

Head `391bf8f5b5fefeee05c53521cdbbebdf7b5fd047` is the clean RA-1 continuation on the selected `84571b4c2a5262dfa52b66772d0276485d150f20` lineage. It contains the bounded stale-inbound ordinary replay correction and PR #23's separately qualified native-suite closure.

Since the original handoff, Core PR #51 (`6676d2df...`) introduced a DEBUG counted-CloudKit evidence boundary that depends on the target integration branch's prepared-upload SPI at `3777968a...`. The correct composed BigSync candidate therefore now requires both histories. This PR is intentionally merged onto `codex/ra1-pro-w1-integration-20260912` to preserve the prepared-upload SPI while adding the clean replay/native-suite closure.

## Production behavior

`RealmSwiftInboundTargetChangedError` schedules a one-second ordinary delayed replay through the existing synchronization-attempt/cancellation fences. Successful upload/deletion acknowledgement may expose a newer target generation; short successful batches remain in their owned mutation drain while the adapter still reports pending work. Durable recovery remains `longLivedOperationID` plus the client token. No production authority/recovery fence is weakened.

The only additional authority change is inside the legacy DEBUG record-zone-rebinding fixture, which initializes real `BackupDetection` evidence for the rebound namespace. Removing that evidence still yields `.staleAuthority`.

## Qualification

Final closure run `34728610055` reapplied the exact four-file closure patch on `b1cde24b2e22e68a5cd056b865bc53f7fd491e2a` and completed the full macOS package suite: **682 tests, 0 failures, 0 unexpected**. Evidence artifact `10309196325`, digest `sha256:21af471206906403e3e872cf215655cd694a73d7ec994f08ec861397c264a1bd`; source.patch SHA-256 `cb00f0b57ef6b3bd6c29cdac92933e7f62c1443616af334ab4a7459d7b41bacf`. Publication run `34728873369` verified the patch hash and four-file allowlist before publishing the clean commit.

This is package-level macOS qualification only. Composed app-native execution, exact-tuple v1 capacity, authentic released migration fixtures, signed disposable CloudKit including concurrent A/B B-survives-A-Undo, release authorization, and production activation remain false gates.