### PR TITLE
Close native suite authority fixture and acknowledgement-created mutation tails

### DIFF
--- a/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+RecordMutations.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+RecordMutations.swift
@@ -294,8 +294,14 @@ extension CloudKitSynchronizer {
                records.count >= requestedBatchSize {
                 increaseBatchSize()
             }
+            // A successful acknowledgement can forward a newer target journal
+            // generation into tracking. A short batch is therefore not proof of
+            // quiescence. Give newly published record work another preparation
+            // turn; deletion-only or differently restricted work yields an empty
+            // record batch and returns immediately to its owning phase.
             guard handledFailures > 0
-                    || records.count >= requestedBatchSize else { return }
+                    || records.count >= requestedBatchSize
+                    || adapter.hasChanges else { return }
             await Task.yield()
         }
     }
@@ -454,7 +460,13 @@ extension CloudKitSynchronizer {
             if handledFailures == 0, recordIDs.count >= requestedBatchSize {
                 increaseBatchSize()
             }
-            guard handledFailures > 0 || recordIDs.count >= requestedBatchSize else { return }
+            // Deletion acknowledgement has the same journal-forwarding
+            // semantics as upload acknowledgement. If it exposes a newer
+            // deletion generation, consume it in this owned deletion drain
+            // instead of deferring it solely because the prior batch was short.
+            guard handledFailures > 0
+                    || recordIDs.count >= requestedBatchSize
+                    || adapter.hasChanges else { return }
             await Task.yield()
         }
     }

--- a/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer.swift
+++ b/Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer.swift
@@ -3466,6 +3466,28 @@ public class CloudKitSynchronizer: NSObject {
                 databaseScope: database.databaseScope,
                 recordZoneID: adapter.recordZoneID
             )
+            // The initializer created backup/installation state for the original
+            // zone. This legacy DEBUG fixture hook must initialize the rebound
+            // namespace too; ordinary outbound admission still requires its
+            // real installation sentinel and must never bypass that proof.
+            do {
+                let result = try BackupDetection.run(
+                    store: keyValueStore,
+                    namespace: durableStateNamespace,
+                    sharedSentinelBaseURL: backupDetectionBaseURL
+                )
+                refreshBackupRestoreRequirement()
+                if result == .restoredFromBackup || backupRestoreDetected {
+                    accountScopeAuthorityFence.poison()
+                    clearDeviceIdentifier()
+                    try invalidateAccountScopeLeaseDurably()
+                    queueAccountScopeInvalidation(.restoreDetected)
+                }
+            } catch {
+                accountScopeAuthorityFence.poison()
+                backupDetectionError = error
+                logger.error("QSCloudKitSynchronizer >> Rebound fixture backup detection failed: \(error)")
+            }
         }
         allowsRecordZoneRebindingForTesting = false
 #endif

--- a/Tests/BigSyncKitTests/BigSyncKitTests.swift
+++ b/Tests/BigSyncKitTests/BigSyncKitTests.swift
@@ -560,6 +560,8 @@ private final class FakeModelAdapter:
     var resetSyncCachesHandler: (@Sendable () async throws -> Void)?
     var saveChangesHandler: (@Sendable () async throws -> Void)?
     var recordsToUploadHandler: (@Sendable () async throws -> Void)?
+    @BigSyncBackgroundActor var didDeleteHandler:
+        (@BigSyncBackgroundActor @Sendable () async throws -> Void)?
     var terminalPendingChanges = false
     var semanticBlockers = [CloudKitSynchronizer.DomainBlocker]()
     var domainHookInvocationCount = 0
@@ -585,6 +587,11 @@ private final class FakeModelAdapter:
         self.priorityEntityTypeNames = priorities
         self.uploadedByEntity = uploadedByEntity
         self.deletedByEntity = deletedByEntity
+    }
+
+    @BigSyncBackgroundActor
+    func enqueueDeletion(_ recordID: CKRecord.ID, entityType: String) {
+        deletedByEntity[entityType, default: []].append(recordID)
     }
 
     func cleanUp() async throws {
@@ -689,6 +696,7 @@ private final class FakeModelAdapter:
     ) async throws {
         let recordNames = recordIDs.map { $0.recordName }.joined(separator: ",")
         events.append("didDelete:\(recordNames)")
+        try await didDeleteHandler?()
         if repeatsPreparedDeletions {
             let acknowledged = Set(recordIDs)
             for entityType in deletedByEntity.keys {
@@ -16138,6 +16146,67 @@ final class BigSyncKitTests: XCTestCase {
     ) async throws {
         try await prepareDirectOutboundAuthority(synchronizer)
         try await synchronizer.synchronizeAdapter(adapter)
+    }
+
+    @BigSyncBackgroundActor
+    func testReboundFixtureInitializesItsActualOutboundNamespace() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("rebound-outbound-" + UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let synchronizer = makeSynchronizer(backupDetectionBaseURL: root)
+        let initialNamespace = synchronizer.durableStateNamespace
+        let initialInstallation = try XCTUnwrap(BackupDetection.installationIdentifier(
+            namespace: initialNamespace, sharedSentinelBaseURL: root))
+        let adapter = FakeModelAdapter(
+            zoneID: CKRecordZone.ID(zoneName: "rebound-outbound-zone"), priorities: [])
+        synchronizer.addModelAdapter(adapter)
+        let selectedNamespace = synchronizer.durableStateNamespace
+        XCTAssertNotEqual(selectedNamespace, initialNamespace)
+        let selectedInstallation = try XCTUnwrap(BackupDetection.installationIdentifier(
+            namespace: selectedNamespace, sharedSentinelBaseURL: root))
+        XCTAssertEqual(BackupDetection.installationIdentifier(
+            namespace: initialNamespace, sharedSentinelBaseURL: root), initialInstallation)
+        try await prepareDirectOutboundAuthority(synchronizer)
+        let context = try XCTUnwrap(synchronizer.activeRunContext)
+        let principal = try synchronizer.currentOutboundPrincipal(for: context)
+        XCTAssertEqual(principal.installationIdentifier, selectedInstallation)
+        XCTAssertEqual(principal.durableStateNamespace, selectedNamespace)
+        // The fix initializes real evidence; it must not relax its admission.
+        try FileManager.default.removeItem(at: root)
+        XCTAssertThrowsError(try synchronizer.currentOutboundPrincipal(for: context)) {
+            XCTAssertEqual($0 as? BigSyncOutboundQuiescenceError, .staleAuthority)
+        }
+    }
+
+    @BigSyncBackgroundActor
+    func testDeletionAcknowledgementCreatedDeletionDrainsInSameAdapterPass() async throws {
+        let database = FakeCloudKitDatabase()
+        let zoneID = CKRecordZone.ID(
+            zoneName: "ack-created-deletion-zone",
+            ownerName: CKCurrentUserDefaultName
+        )
+        let first = CKRecord.ID(recordName: "Bookmark.first", zoneID: zoneID)
+        let second = CKRecord.ID(recordName: "Bookmark.second", zoneID: zoneID)
+        let adapter = FakeModelAdapter(
+            zoneID: zoneID,
+            priorities: [],
+            deletedByEntity: ["Bookmark": [first]]
+        )
+        adapter.didDeleteHandler = {
+            adapter.didDeleteHandler = nil
+            adapter.enqueueDeletion(second, entityType: "Bookmark")
+        }
+        let synchronizer = makeSynchronizer(database: database)
+        synchronizer.addModelAdapter(adapter)
+
+        try await synchronizeAdapterWithOutboundAuthority(synchronizer, adapter)
+
+        XCTAssertEqual(database.modifyRecordsOperationCount, 2)
+        XCTAssertEqual(
+            adapter.events.filter { $0.hasPrefix("didDelete:") },
+            ["didDelete:Bookmark.first", "didDelete:Bookmark.second"]
+        )
+        XCTAssertFalse(adapter.hasChanges)
     }
 
     @BigSyncBackgroundActor

--- a/Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift
+++ b/Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift
@@ -754,6 +754,17 @@ final class OwnedRecordRevisionTests: XCTestCase {
             runID: sync.synchronizationRunID, accountIdentifier: account,
             accountScopeIdentifier: lease.accountScopeIdentifier,
             replicaBindingGenerationIdentifier: binding, accountInvalidationGeneration: lease.invalidationGeneration)
+        // This helper owns a direct adapter drain, not a background full sync.
+        // Mirror the enclosing production drain's ownership so normal journal
+        // delegate wakeups coalesce instead of starting a second attempt that
+        // the deliberately upload-only transport cannot service.
+        let attemptID = sync.synchronizationAttemptID
+        sync.syncing = true
+        sync.synchronizationDrainIsActive = true
+        defer {
+            sync.cancelSynchronization()
+            try? FileManager.default.removeItem(at: root)
+        }
         // Seed an unchanged foreign value through inbound replication, then make
         // it a normal repair upload. Do not author owner-a with this random
         // installation's identity merely to arrange the transport fixture.
@@ -771,6 +782,10 @@ final class OwnedRecordRevisionTests: XCTestCase {
         try await sync.synchronizeAdapter(f.adapter)
         await f.refresh()
         let uploads = await io.uploadedValues()
+        XCTAssertEqual(sync.synchronizationAttemptID, attemptID,
+                       "A journal wakeup must not replace the owned direct drain")
+        XCTAssertTrue(sync.syncing)
+        XCTAssertNil(sync.synchronizationTask)
         XCTAssertEqual(uploads.first, local)
         XCTAssertTrue((2...3).contains(uploads.count))
         XCTAssertTrue(uploads.dropFirst().allSatisfy { $0 == expected },


### PR DESCRIPTION
## Exact continuation

Base: `b1cde24b2e22e68a5cd056b865bc53f7fd491e2a` (`codex/ra1-final-inbound-replay-20260912`).

This is the clean, qualified continuation of the already-selected inbound-target replay source. It intentionally does **not** target the moving BigSync integration branch, so the separately unselected prepared-upload SPI is not pulled into the RA-1 tuple.

Exactly four files change:

- `Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer.swift`
- `Sources/BigSyncKit/QSSynchronizer/CloudKitSynchronizer+RecordMutations.swift`
- `Tests/BigSyncKitTests/BigSyncKitTests.swift`
- `Tests/BigSyncKitTests/OwnedRecordRevisionTests.swift`

## Corrections

1. The legacy DEBUG record-zone-rebinding fixture now initializes real `BackupDetection` state for the rebound durable namespace. Production outbound admission remains unchanged: deleting that sentinel still produces `.staleAuthority`; no fence or recovery requirement is weakened.
2. A successful upload acknowledgement may expose a newer target generation. A short successful batch therefore no longer terminates the owned record drain while the adapter still has pending work.
3. The same acknowledgement-created tail rule is applied to deletion drains.
4. The direct OwnedRecordRevision conflict helper explicitly owns its direct drain so the journal wakeup coalesces instead of launching an unrelated full synchronization against its deliberately upload-only scripted transport.

Durable CloudKit recovery identity remains `longLivedOperationID` plus the client token. No `submittedOperationID` machinery is added or changed.

## Exact qualification

Run `34728610055` reconstructs this patch on exactly `b1cde24...` and executes the full macOS SwiftPM package suite:

- **682 tests, 0 failures, 0 unexpected**
- evidence artifact `10309196325`
- artifact digest `sha256:21af471206906403e3e872cf215655cd694a73d7ec994f08ec861397c264a1bd`
- exact `source.patch` SHA-256 `cb00f0b57ef6b3bd6c29cdac92933e7f62c1443616af334ab4a7459d7b41bacf`

The same run performs a negative control by reverting only the rebound-namespace fixture repair: `testReboundFixtureInitializesItsActualOutboundNamespace` then fails as expected because the rebound namespace lacks its installation sentinel. Restoring the exact patch makes the focused test pass again.

Publication run `34728873369`, job `103647874961`, independently reapplies that exact patch, verifies its hash and four-file allowlist, and publishes this clean one-commit continuation directly on `b1cde24...`.

This establishes package-level macOS qualification only. It does not claim composed app-native, v1 capacity, released-fixture, signed CloudKit, release, or production qualification.